### PR TITLE
fix: prevent race condition that clears thread messages

### DIFF
--- a/packages/desktop/src/renderer/hooks/useChat.ts
+++ b/packages/desktop/src/renderer/hooks/useChat.ts
@@ -235,12 +235,11 @@ export function useChat(activeThreadId: string | null, options?: UseChatOptions)
 
       let state = streamingThreadsRef.current.get(threadId)
       if (!state) {
-        // Don't create a new empty state for terminal events — these are
-        // late arrivals after interrupt() already saved and cleaned up.
-        // Creating an empty state here would clobber React messages via apply().
-        if (msg.type === 'result' || msg.type === 'error') return
-        state = { messages: [], assistantId: null, activeTaskId: null }
-        streamingThreadsRef.current.set(threadId, state)
+        // No streaming state means the stream was already finalized (by result/error)
+        // or cleaned up (by interrupt timeout). Any event arriving now is a late
+        // arrival — creating a new empty state would clobber accumulated messages
+        // via setMessages(). Ignore all late arrivals, not just terminal events.
+        return
       }
 
       const apply = (updater: (msgs: ChatMessage[]) => ChatMessage[]) => {
@@ -720,12 +719,14 @@ export function useChat(activeThreadId: string | null, options?: UseChatOptions)
         if (isRunning) return prev.includes(threadId) ? prev : [...prev, threadId]
         return prev.filter(id => id !== threadId)
       })
-      // Safety net: clean up lingering streaming state when the main process
-      // confirms the stream ended. Normally result/error events handle this,
-      // but this catches edge cases where no terminal event arrives.
-      if (!isRunning) {
-        streamingThreadsRef.current.delete(threadId)
-      }
+      // NOTE: Do NOT delete streamingThreadsRef here. This event arrives on a
+      // different IPC channel than STREAM_MESSAGE, so ordering is not guaranteed.
+      // If we delete the streaming state before the final stream events arrive,
+      // late non-terminal events (text, tool_result) create a new empty state
+      // with messages: [], which clobbers accumulated messages via setMessages().
+      // The result/error handlers in onStreamMessage already handle cleanup
+      // after saving messages. For the edge case where no terminal event arrives,
+      // interrupt() sets a 5s timeout to force-clear the state.
     })
 
     // Pull any already-cached commands (handles reload via cmd+r)

--- a/packages/ui/src/components/ChatView.tsx
+++ b/packages/ui/src/components/ChatView.tsx
@@ -58,7 +58,6 @@ export function ChatView({ messages, isStreaming, onLinkClick, onSendMessage, on
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-semibold text-gray-300 mb-2">AgentPanel</h1>
-          <p className="text-sm text-gray-500">Open Source AI Agent Desktop</p>
           <p className="text-xs text-gray-600 mt-4">Type a message to get started</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Fix race condition** where `onThreadStreamState(!isRunning)` arrives on a different IPC channel before final stream events, prematurely deleting streaming state. Late non-terminal events then created empty state and clobbered all messages via `setMessages([])`.
- **Harden late-event guard** to ignore ALL event types (not just result/error) when no streaming state exists.
- **Remove subtitle** "Open Source AI Agent Desktop" from empty chat state.

## Test plan
- [ ] Start a long conversation with multiple tool calls
- [ ] Verify all messages persist after the stream completes
- [ ] Switch threads and switch back — messages should still be there
- [ ] Interrupt a running stream — messages before interrupt should persist
- [ ] Reload the app — thread history should be intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)