### PR TITLE
fix: hardcode AgentPanel header colors

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -140,15 +140,10 @@ if (!gotLock) {
     setThreadSessionClearer((threadId: string) => agentManager?.clearSession(threadId))
     setRunningThreadsGetter(() => agentManager?.getRunningThreadIds() ?? [])
 
-    // App info (worktree, accent color, CDP port)
-    const ACCENT_COLORS = ['text-blue-500', 'text-green-500', 'text-orange-500', 'text-purple-500', 'text-pink-500', 'text-cyan-500']
-    const accentColor = worktree
-      ? ACCENT_COLORS[parseInt(worktree.hash.slice(0, 4), 16) % ACCENT_COLORS.length]
-      : 'text-blue-500'
+    // App info (worktree, CDP port)
     ipcMain.handle(IPC_CHANNELS.APP_INFO, () => ({
       isWorktree: !!worktree,
       worktreeName: worktree?.name ?? null,
-      accentColor,
       cdpPort
     }))
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -92,7 +92,7 @@ const api = {
     ipcRenderer.invoke(IPC_CHANNELS.THREADS_RECOVER_ORPHANED, threadId),
 
   // App info
-  getAppInfo: (): Promise<{ isWorktree: boolean; worktreeName: string | null; accentColor: string; cdpPort: number | null }> =>
+  getAppInfo: (): Promise<{ isWorktree: boolean; worktreeName: string | null; cdpPort: number | null }> =>
     ipcRenderer.invoke(IPC_CHANNELS.APP_INFO),
 
   // App settings

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -71,15 +71,13 @@ export default function App(): React.ReactElement {
   const [homeDir, setHomeDir] = useState('')
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
-  const [accentColor, setAccentColor] = useState('text-blue-500')
   const inputRef = useRef<InputBarRef | null>(null)
   const draftsRef = useRef<Map<string, string>>(new Map())
   const prevActiveThreadIdRef = useRef<string | null>(null)
 
-  // Fetch home directory and app info
+  // Fetch home directory
   useEffect(() => {
     window.api.getHomeDirectory().then(setHomeDir)
-    window.api.getAppInfo().then((info) => setAccentColor(info.accentColor))
   }, [])
 
   // Save/restore draft input text when switching threads
@@ -303,7 +301,7 @@ export default function App(): React.ReactElement {
           onSettingsClick={() => setShowSettingsDialog(true)}
           runningThreadIds={runningThreadIds}
           threadNotifications={threadNotifications}
-          accentColor={accentColor}
+
         />
       </div>
 

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -11,7 +11,6 @@ interface Props {
   onSettingsClick: () => void
   runningThreadIds: string[]
   threadNotifications: Map<string, string>
-  accentColor?: string
 }
 
 export function Sidebar({
@@ -23,8 +22,7 @@ export function Sidebar({
   onToggleSidebar,
   onSettingsClick,
   runningThreadIds,
-  threadNotifications,
-  accentColor = 'text-blue-500'
+  threadNotifications
 }: Props): React.ReactElement {
   return (
     <div className="flex-shrink-0 flex flex-col bg-[#0a0a0a] overflow-hidden w-[232px] min-w-[232px] h-full">
@@ -34,7 +32,7 @@ export function Sidebar({
         {/* Header with logo */}
         <div className="flex-shrink-0 flex items-center justify-between px-3 pb-1">
           <span className="font-semibold text-gray-200">
-            Agent<span className={accentColor}>Panel</span>
+            Agent<span className="text-blue-500">Panel</span>
           </span>
           <button
             onClick={onToggleSidebar}


### PR DESCRIPTION
## Summary
- Remove dynamic accent color derived from worktree hash — it was getting purged by Tailwind CSS since the class names lived outside the `@source` scan path
- Hardcode "Agent" as white (`text-gray-200`) and "Panel" as blue (`text-blue-500`) directly in the Sidebar component

## Test plan
- [x] Build passes
- [x] All 31 tests pass
- [x] Visually verified via CDP screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)