### PR TITLE
feat: folder-based thread organization

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,21 +1,50 @@
 // Types
-export type { Thread, StoredMessage, StoredToolCall, AgentMode, ThreadWorktree, WorktreeProgressStep, WorktreeProgressData, StoredImageAttachment } from './types/thread'
-export { normalizeMode } from './types/thread'
-export type { ModeConfig } from './types/mode'
-export { MODE_CONFIGS, AGENT_MODES } from './types/mode'
+export type {
+  Thread,
+  Folder,
+  StoredMessage,
+  StoredToolCall,
+  AgentMode,
+  ThreadWorktree,
+  WorktreeProgressStep,
+  WorktreeProgressData,
+  StoredImageAttachment,
+} from "./types/thread";
+export { normalizeMode } from "./types/thread";
+export type { ModeConfig } from "./types/mode";
+export { MODE_CONFIGS, AGENT_MODES } from "./types/mode";
 
 // Providers
-export type { AgentProvider, AgentMessage, ProviderConfig, SendMessageParams, AgentDefinition, PermissionHandler, TokenUsage, ModelInfo, TodoItem } from './providers/types'
-export { READ_ONLY_TOOLS } from './providers/types'
-export { ClaudeCodeProvider } from './providers/claude-code.provider'
-export { createProvider, getAvailableProviders } from './providers/index'
+export type {
+  AgentProvider,
+  AgentMessage,
+  ProviderConfig,
+  SendMessageParams,
+  AgentDefinition,
+  PermissionHandler,
+  TokenUsage,
+  ModelInfo,
+  TodoItem,
+} from "./providers/types";
+export { READ_ONLY_TOOLS } from "./providers/types";
+export { ClaudeCodeProvider } from "./providers/claude-code.provider";
+export { createProvider, getAvailableProviders } from "./providers/index";
 
 // Storage
-export type { StorageAdapter } from './storage/types'
-export { FileStorageAdapter } from './storage/file-adapter'
-export type { TraceEntry } from './storage/trace.store'
-export { appendTraceEntry, readTraceEntries, clearTraceFile } from './storage/trace.store'
+export type { StorageAdapter } from "./storage/types";
+export { FileStorageAdapter } from "./storage/file-adapter";
+export type { TraceEntry } from "./storage/trace.store";
+export {
+  appendTraceEntry,
+  readTraceEntries,
+  clearTraceFile,
+} from "./storage/trace.store";
 
 // Utils
-export type { WorktreeInfo } from './utils/worktree'
-export { detectWorktreeRoot, deriveHash, derivePort, getWorktreeInfo } from './utils/worktree'
+export type { WorktreeInfo } from "./utils/worktree";
+export {
+  detectWorktreeRoot,
+  deriveHash,
+  derivePort,
+  getWorktreeInfo,
+} from "./utils/worktree";

--- a/packages/core/src/storage/file-adapter.ts
+++ b/packages/core/src/storage/file-adapter.ts
@@ -1,155 +1,211 @@
-import { join } from 'path'
-import { homedir } from 'os'
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'fs'
-import type { Thread, StoredMessage } from '../types/thread'
-import type { StorageAdapter } from './types'
-import { clearTraceFile } from './trace.store'
+import { basename, join } from "path";
+import { homedir } from "os";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+} from "fs";
+import type { Thread, Folder, StoredMessage } from "../types/thread";
+import type { StorageAdapter } from "./types";
+import { clearTraceFile } from "./trace.store";
 
-const DEFAULT_BASE_DIR = join(homedir(), '.agentpanel')
+const DEFAULT_BASE_DIR = join(homedir(), ".agentpanel");
 
 interface ThreadsFile {
-  threads: Thread[]
-  activeThreadId: string | null
+  folders?: Folder[];
+  threads: Thread[];
+  activeThreadId: string | null;
 }
 
 export class FileStorageAdapter implements StorageAdapter {
-  private baseDir: string
+  private baseDir: string;
 
   constructor(baseDir?: string) {
-    this.baseDir = baseDir ?? DEFAULT_BASE_DIR
+    this.baseDir = baseDir ?? DEFAULT_BASE_DIR;
   }
 
   private getThreadsDir(): string {
-    const dir = join(this.baseDir, 'threads')
+    const dir = join(this.baseDir, "threads");
     if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
+      mkdirSync(dir, { recursive: true });
     }
-    return dir
+    return dir;
   }
 
   private getThreadsPath(): string {
-    return join(this.getThreadsDir(), 'threads.json')
+    return join(this.getThreadsDir(), "threads.json");
   }
 
   private getMessagesPath(threadId: string): string {
-    return join(this.getThreadsDir(), 'messages', `${threadId}.json`)
+    return join(this.getThreadsDir(), "messages", `${threadId}.json`);
   }
 
   private loadThreadsFile(): ThreadsFile {
-    const path = this.getThreadsPath()
+    const path = this.getThreadsPath();
     if (!existsSync(path)) {
-      return { threads: [], activeThreadId: null }
+      return { threads: [], activeThreadId: null };
     }
     try {
-      const raw = readFileSync(path, 'utf-8')
-      return JSON.parse(raw) as ThreadsFile
+      const raw = readFileSync(path, "utf-8");
+      return JSON.parse(raw) as ThreadsFile;
     } catch {
-      return { threads: [], activeThreadId: null }
+      return { threads: [], activeThreadId: null };
     }
   }
 
   private saveThreadsFile(data: ThreadsFile): void {
-    writeFileSync(this.getThreadsPath(), JSON.stringify(data, null, 2), 'utf-8')
+    writeFileSync(
+      this.getThreadsPath(),
+      JSON.stringify(data, null, 2),
+      "utf-8",
+    );
   }
 
   listThreads(): Thread[] {
-    const { threads } = this.loadThreadsFile()
-    return [...threads].sort((a, b) => b.createdAt - a.createdAt)
+    const { threads } = this.loadThreadsFile();
+    return [...threads].sort((a, b) => b.createdAt - a.createdAt);
   }
 
   getThread(threadId: string): Thread | null {
-    const { threads } = this.loadThreadsFile()
-    return threads.find((t) => t.id === threadId) ?? null
+    const { threads } = this.loadThreadsFile();
+    return threads.find((t) => t.id === threadId) ?? null;
   }
 
-  createThread(title = 'New chat', model?: string, cwd?: string): Thread {
-    const id = `thread_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
-    const now = Date.now()
+  createThread(title = "New chat", model?: string, cwd?: string): Thread {
+    const id = `thread_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    const now = Date.now();
     const thread: Thread = {
       id,
       title,
       createdAt: now,
       updatedAt: now,
       ...(model ? { model } : {}),
-      ...(cwd ? { cwd } : {})
-    }
+      ...(cwd ? { cwd } : {}),
+    };
 
-    const data = this.loadThreadsFile()
-    data.threads.push(thread)
-    data.activeThreadId = id
-    this.saveThreadsFile(data)
+    const data = this.loadThreadsFile();
+    data.threads.push(thread);
+    data.activeThreadId = id;
+    this.saveThreadsFile(data);
 
-    return thread
+    return thread;
   }
 
   updateThread(threadId: string, updates: Partial<Thread>): Thread | null {
-    const data = this.loadThreadsFile()
-    const idx = data.threads.findIndex((t) => t.id === threadId)
-    if (idx === -1) return null
+    const data = this.loadThreadsFile();
+    const idx = data.threads.findIndex((t) => t.id === threadId);
+    if (idx === -1) return null;
 
-    const thread = { ...data.threads[idx], ...updates, updatedAt: Date.now() }
-    data.threads[idx] = thread
-    this.saveThreadsFile(data)
-    return thread
+    const thread = { ...data.threads[idx], ...updates, updatedAt: Date.now() };
+    data.threads[idx] = thread;
+    this.saveThreadsFile(data);
+    return thread;
   }
 
   deleteThread(threadId: string): boolean {
-    const data = this.loadThreadsFile()
-    const idx = data.threads.findIndex((t) => t.id === threadId)
-    if (idx === -1) return false
+    const data = this.loadThreadsFile();
+    const idx = data.threads.findIndex((t) => t.id === threadId);
+    if (idx === -1) return false;
 
-    data.threads.splice(idx, 1)
+    data.threads.splice(idx, 1);
     if (data.activeThreadId === threadId) {
-      data.activeThreadId = data.threads.length > 0 ? data.threads[0].id : null
+      data.activeThreadId = data.threads.length > 0 ? data.threads[0].id : null;
     }
-    this.saveThreadsFile(data)
+    this.saveThreadsFile(data);
 
-    const msgPath = this.getMessagesPath(threadId)
+    const msgPath = this.getMessagesPath(threadId);
     if (existsSync(msgPath)) {
-      unlinkSync(msgPath)
+      unlinkSync(msgPath);
     }
 
-    clearTraceFile(threadId, this.baseDir)
+    clearTraceFile(threadId, this.baseDir);
 
-    return true
+    return true;
   }
 
   getActiveThreadId(): string | null {
-    return this.loadThreadsFile().activeThreadId
+    return this.loadThreadsFile().activeThreadId;
   }
 
   setActiveThreadId(threadId: string | null): void {
-    const data = this.loadThreadsFile()
-    data.activeThreadId = threadId
-    this.saveThreadsFile(data)
+    const data = this.loadThreadsFile();
+    data.activeThreadId = threadId;
+    this.saveThreadsFile(data);
   }
 
   clearPersistedSessionId(threadId: string): void {
-    const data = this.loadThreadsFile()
-    const idx = data.threads.findIndex((t) => t.id === threadId)
-    if (idx === -1) return
-    delete data.threads[idx].sessionId
-    data.threads[idx].updatedAt = Date.now()
-    this.saveThreadsFile(data)
+    const data = this.loadThreadsFile();
+    const idx = data.threads.findIndex((t) => t.id === threadId);
+    if (idx === -1) return;
+    delete data.threads[idx].sessionId;
+    data.threads[idx].updatedAt = Date.now();
+    this.saveThreadsFile(data);
   }
 
   loadMessages(threadId: string): StoredMessage[] {
-    const path = this.getMessagesPath(threadId)
-    if (!existsSync(path)) return []
+    const path = this.getMessagesPath(threadId);
+    if (!existsSync(path)) return [];
     try {
-      const raw = readFileSync(path, 'utf-8')
-      return JSON.parse(raw) as StoredMessage[]
+      const raw = readFileSync(path, "utf-8");
+      return JSON.parse(raw) as StoredMessage[];
     } catch {
-      return []
+      return [];
     }
   }
 
   saveMessages(threadId: string, messages: StoredMessage[]): void {
-    const dir = join(this.getThreadsDir(), 'messages')
+    const dir = join(this.getThreadsDir(), "messages");
     if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
+      mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(this.getMessagesPath(threadId), JSON.stringify(messages, null, 2), 'utf-8')
-    this.updateThread(threadId, {})
+    writeFileSync(
+      this.getMessagesPath(threadId),
+      JSON.stringify(messages, null, 2),
+      "utf-8",
+    );
+    this.updateThread(threadId, {});
+  }
+
+  listFolders(): Folder[] {
+    const data = this.loadThreadsFile();
+    return [...(data.folders ?? [])].sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  addFolder(path: string, name?: string): Folder {
+    const data = this.loadThreadsFile();
+    if (!data.folders) data.folders = [];
+
+    // Don't add duplicate paths
+    const existing = data.folders.find((f) => f.path === path);
+    if (existing) return existing;
+
+    const folder: Folder = {
+      id: `folder_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      name: name ?? basename(path),
+      path,
+      createdAt: Date.now(),
+    };
+    data.folders.push(folder);
+    this.saveThreadsFile(data);
+    return folder;
+  }
+
+  removeFolder(folderId: string): void {
+    const data = this.loadThreadsFile();
+    if (!data.folders) return;
+    data.folders = data.folders.filter((f) => f.id !== folderId);
+    this.saveThreadsFile(data);
+  }
+
+  updateFolder(folderId: string, updates: Partial<Folder>): Folder | null {
+    const data = this.loadThreadsFile();
+    if (!data.folders) return null;
+    const idx = data.folders.findIndex((f) => f.id === folderId);
+    if (idx === -1) return null;
+    data.folders[idx] = { ...data.folders[idx], ...updates };
+    this.saveThreadsFile(data);
+    return data.folders[idx];
   }
 }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,4 +1,4 @@
-import type { Thread, StoredMessage } from '../types/thread'
+import type { Thread, Folder, StoredMessage } from "../types/thread";
 
 /**
  * Storage adapter interface for thread persistence.
@@ -6,14 +6,20 @@ import type { Thread, StoredMessage } from '../types/thread'
  * The default FileStorageAdapter stores them as JSON on disk.
  */
 export interface StorageAdapter {
-  listThreads(): Thread[]
-  getThread(threadId: string): Thread | null
-  createThread(title?: string, model?: string, cwd?: string): Thread
-  updateThread(threadId: string, updates: Partial<Thread>): Thread | null
-  deleteThread(threadId: string): boolean
-  getActiveThreadId(): string | null
-  setActiveThreadId(threadId: string | null): void
-  clearPersistedSessionId(threadId: string): void
-  loadMessages(threadId: string): StoredMessage[]
-  saveMessages(threadId: string, messages: StoredMessage[]): void
+  listThreads(): Thread[];
+  getThread(threadId: string): Thread | null;
+  createThread(title?: string, model?: string, cwd?: string): Thread;
+  updateThread(threadId: string, updates: Partial<Thread>): Thread | null;
+  deleteThread(threadId: string): boolean;
+  getActiveThreadId(): string | null;
+  setActiveThreadId(threadId: string | null): void;
+  clearPersistedSessionId(threadId: string): void;
+  loadMessages(threadId: string): StoredMessage[];
+  saveMessages(threadId: string, messages: StoredMessage[]): void;
+
+  // Folders
+  listFolders(): Folder[];
+  addFolder(path: string, name?: string): Folder;
+  removeFolder(folderId: string): void;
+  updateFolder(folderId: string, updates: Partial<Folder>): Folder | null;
 }

--- a/packages/core/src/types/thread.ts
+++ b/packages/core/src/types/thread.ts
@@ -1,77 +1,90 @@
-export type AgentMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions'
+export type AgentMode =
+  | "plan"
+  | "default"
+  | "acceptEdits"
+  | "bypassPermissions";
 
 /** Normalize legacy 'execute' values from stored threads */
 export function normalizeMode(mode: string | undefined): AgentMode {
-  if (!mode || mode === 'execute') return 'default'
-  if (['plan', 'default', 'acceptEdits', 'bypassPermissions'].includes(mode))
-    return mode as AgentMode
-  return 'default'
+  if (!mode || mode === "execute") return "default";
+  if (["plan", "default", "acceptEdits", "bypassPermissions"].includes(mode))
+    return mode as AgentMode;
+  return "default";
 }
 
 export interface StoredImageAttachment {
-  id: string
-  name: string
-  dataUrl: string
-  mimeType: string
+  id: string;
+  name: string;
+  dataUrl: string;
+  mimeType: string;
+}
+
+export interface Folder {
+  id: string;
+  name: string;
+  path: string;
+  isGitRepo?: boolean;
+  collapsed?: boolean;
+  createdAt: number;
 }
 
 export interface ThreadWorktree {
-  path: string
-  branch: string
-  sourceRepoPath: string
+  path: string;
+  branch: string;
+  sourceRepoPath: string;
 }
 
 export interface Thread {
-  id: string
-  title: string
-  createdAt: number
-  updatedAt: number
-  model?: string
-  cwd?: string
-  thinkingEffort?: 'low' | 'medium' | 'high' | 'max'
-  mode?: AgentMode
-  additionalCwds?: string[]
-  sessionId?: string
-  isGitRepo?: boolean
-  worktreeMode?: 'local' | 'worktree'
-  worktree?: ThreadWorktree
-  sessionTools?: string[]
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  model?: string;
+  cwd?: string;
+  thinkingEffort?: "low" | "medium" | "high" | "max";
+  mode?: AgentMode;
+  additionalCwds?: string[];
+  sessionId?: string;
+  isGitRepo?: boolean;
+  worktreeMode?: "local" | "worktree";
+  worktree?: ThreadWorktree;
+  sessionTools?: string[];
 }
 
 export interface WorktreeProgressStep {
-  step: string
-  status: 'running' | 'completed' | 'error'
+  step: string;
+  status: "running" | "completed" | "error";
 }
 
 export interface WorktreeProgressData {
-  steps: WorktreeProgressStep[]
+  steps: WorktreeProgressStep[];
 }
 
 export interface StoredMessage {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  timestamp: number
-  toolCalls?: StoredToolCall[]
-  taskInfo?: unknown
-  cost?: number
-  usage?: { inputTokens: number; outputTokens: number }
-  contextWindow?: number
-  thinking?: string
-  modeChange?: AgentMode
-  questionData?: unknown
-  questionAnswered?: boolean
-  planReviewData?: unknown
-  todoData?: unknown
-  worktreeProgress?: WorktreeProgressData
-  images?: StoredImageAttachment[]
-  stop_reason?: 'end_turn' | 'max_tokens' | 'stop_sequence' | null
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: number;
+  toolCalls?: StoredToolCall[];
+  taskInfo?: unknown;
+  cost?: number;
+  usage?: { inputTokens: number; outputTokens: number };
+  contextWindow?: number;
+  thinking?: string;
+  modeChange?: AgentMode;
+  questionData?: unknown;
+  questionAnswered?: boolean;
+  planReviewData?: unknown;
+  todoData?: unknown;
+  worktreeProgress?: WorktreeProgressData;
+  images?: StoredImageAttachment[];
+  stop_reason?: "end_turn" | "max_tokens" | "stop_sequence" | null;
 }
 
 export interface StoredToolCall {
-  toolCallId: string
-  toolName: string
-  input: Record<string, unknown>
-  output?: string
-  status: 'pending' | 'running' | 'completed' | 'denied'
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  output?: string;
+  status: "pending" | "running" | "completed" | "denied";
 }

--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -1,77 +1,83 @@
 export const IPC_CHANNELS = {
-  SEND_MESSAGE: 'chat:send-message',
-  STREAM_MESSAGE: 'chat:stream-message',
-  TOOL_PERMISSION: 'chat:tool-permission',
-  TOOL_RESPONSE: 'chat:tool-response',
-  INTERRUPT: 'chat:interrupt',
-  SESSION_READY: 'chat:session-ready',
-  GET_AVAILABLE_MODELS: 'provider:get-available-models',
-  SELECT_DIRECTORY: 'settings:select-directory',
-  GET_HOME_DIRECTORY: 'settings:get-home-directory',
-  SETTINGS_GET: 'settings:get',
-  SETTINGS_UPDATE: 'settings:update',
+  SEND_MESSAGE: "chat:send-message",
+  STREAM_MESSAGE: "chat:stream-message",
+  TOOL_PERMISSION: "chat:tool-permission",
+  TOOL_RESPONSE: "chat:tool-response",
+  INTERRUPT: "chat:interrupt",
+  SESSION_READY: "chat:session-ready",
+  GET_AVAILABLE_MODELS: "provider:get-available-models",
+  SELECT_DIRECTORY: "settings:select-directory",
+  GET_HOME_DIRECTORY: "settings:get-home-directory",
+  SETTINGS_GET: "settings:get",
+  SETTINGS_UPDATE: "settings:update",
 
   // Threads / sessions
-  THREADS_LIST: 'chat:threads:list',
-  THREADS_GET_ACTIVE: 'chat:threads:get-active',
-  THREADS_SET_ACTIVE: 'chat:threads:set-active',
-  THREADS_CREATE: 'chat:threads:create',
-  THREADS_GET: 'chat:threads:get',
-  THREADS_UPDATE: 'chat:threads:update',
-  THREADS_DELETE: 'chat:threads:delete',
-  THREADS_LOAD_MESSAGES: 'chat:threads:load-messages',
-  THREADS_SAVE_MESSAGES: 'chat:threads:save-messages',
-  THREADS_READ_TRACE: 'chat:threads:read-trace',
-  THREADS_CLEAR_TRACE: 'chat:threads:clear-trace',
+  THREADS_LIST: "chat:threads:list",
+  THREADS_GET_ACTIVE: "chat:threads:get-active",
+  THREADS_SET_ACTIVE: "chat:threads:set-active",
+  THREADS_CREATE: "chat:threads:create",
+  THREADS_GET: "chat:threads:get",
+  THREADS_UPDATE: "chat:threads:update",
+  THREADS_DELETE: "chat:threads:delete",
+  THREADS_LOAD_MESSAGES: "chat:threads:load-messages",
+  THREADS_SAVE_MESSAGES: "chat:threads:save-messages",
+  THREADS_READ_TRACE: "chat:threads:read-trace",
+  THREADS_CLEAR_TRACE: "chat:threads:clear-trace",
 
   // Thread worktrees
-  THREADS_CREATE_WORKTREE: 'chat:threads:create-worktree',
-  THREADS_CLEANUP_WORKTREE: 'chat:threads:cleanup-worktree',
+  THREADS_CREATE_WORKTREE: "chat:threads:create-worktree",
+  THREADS_CLEANUP_WORKTREE: "chat:threads:cleanup-worktree",
+
+  // Folders
+  FOLDERS_LIST: "chat:folders:list",
+  FOLDERS_ADD: "chat:folders:add",
+  FOLDERS_REMOVE: "chat:folders:remove",
+  FOLDERS_UPDATE: "chat:folders:update",
 
   // Git detection
-  CHECK_IS_GIT_REPO: 'settings:check-is-git-repo',
+  CHECK_IS_GIT_REPO: "settings:check-is-git-repo",
 
   // GitHub — connection management (gh CLI)
-  GITHUB_CHECK_CLI: 'integration:github:check-cli',
-  GITHUB_CONNECT: 'integration:github:connect',
-  GITHUB_DISCONNECT: 'integration:github:disconnect',
-  GITHUB_GET_CONNECTION: 'integration:github:get-connection',
-  GITHUB_LIST_REPOS: 'integration:github:list-repos',
+  GITHUB_CHECK_CLI: "integration:github:check-cli",
+  GITHUB_CONNECT: "integration:github:connect",
+  GITHUB_DISCONNECT: "integration:github:disconnect",
+  GITHUB_GET_CONNECTION: "integration:github:get-connection",
+  GITHUB_LIST_REPOS: "integration:github:list-repos",
 
   // Claude — connection management (claude CLI)
-  CLAUDE_CHECK_CLI: 'integration:claude:check-cli',
-  CLAUDE_CONNECT: 'integration:claude:connect',
-  CLAUDE_DISCONNECT: 'integration:claude:disconnect',
-  CLAUDE_GET_CONNECTION: 'integration:claude:get-connection',
+  CLAUDE_CHECK_CLI: "integration:claude:check-cli",
+  CLAUDE_CONNECT: "integration:claude:connect",
+  CLAUDE_DISCONNECT: "integration:claude:disconnect",
+  CLAUDE_GET_CONNECTION: "integration:claude:get-connection",
 
   // Interactive tool events (AskUserQuestion, plan mode)
-  ASK_USER_QUESTION: 'chat:ask-user-question',
-  ASK_USER_RESPONSE: 'chat:ask-user-response',
-  MODE_CHANGED: 'chat:mode-changed',
-  PLAN_REVIEW: 'chat:plan-review',
-  PLAN_REVIEW_RESPONSE: 'chat:plan-review-response',
+  ASK_USER_QUESTION: "chat:ask-user-question",
+  ASK_USER_RESPONSE: "chat:ask-user-response",
+  MODE_CHANGED: "chat:mode-changed",
+  PLAN_REVIEW: "chat:plan-review",
+  PLAN_REVIEW_RESPONSE: "chat:plan-review-response",
 
   // Preview pane
-  PREVIEW_OPEN_URL: 'preview:open-url',
-  PREVIEW_OPEN_MARKDOWN: 'preview:open-markdown',
+  PREVIEW_OPEN_URL: "preview:open-url",
+  PREVIEW_OPEN_MARKDOWN: "preview:open-markdown",
 
   // Skills
-  SKILLS_LIST: 'skills:list',
-  SLASH_COMMANDS_LIST: 'skills:slash-commands',
-  SLASH_COMMANDS_GET: 'skills:slash-commands-get',
+  SKILLS_LIST: "skills:list",
+  SLASH_COMMANDS_LIST: "skills:slash-commands",
+  SLASH_COMMANDS_GET: "skills:slash-commands-get",
 
   // Parallel thread execution
-  THREAD_STREAM_STATE: 'chat:thread-stream-state',
-  THREADS_RUNNING: 'chat:threads-running',
-  THREAD_ACTIVATE: 'chat:thread-activate',
+  THREAD_STREAM_STATE: "chat:thread-stream-state",
+  THREADS_RUNNING: "chat:threads-running",
+  THREAD_ACTIVATE: "chat:thread-activate",
 
   // Orphaned thread recovery
-  THREADS_ORPHANED: 'chat:threads-orphaned',
-  THREADS_RECOVER_ORPHANED: 'chat:threads:recover-orphaned',
+  THREADS_ORPHANED: "chat:threads-orphaned",
+  THREADS_RECOVER_ORPHANED: "chat:threads:recover-orphaned",
 
   // App info
-  APP_INFO: 'app:info',
+  APP_INFO: "app:info",
 
   // UI shortcuts
-  OPEN_MODEL_PICKER: 'ui:open-model-picker',
-} as const
+  OPEN_MODEL_PICKER: "ui:open-model-picker",
+} as const;

--- a/packages/desktop/src/main/threads/thread.ipc.ts
+++ b/packages/desktop/src/main/threads/thread.ipc.ts
@@ -1,165 +1,261 @@
-import { ipcMain } from 'electron'
-import { execSync } from 'child_process'
-import { join } from 'path'
-import { mkdirSync } from 'fs'
-import { homedir } from 'os'
-import { IPC_CHANNELS } from '../../common/ipc-channels'
-import { FileStorageAdapter, readTraceEntries, clearTraceFile } from '@agentpanel/core'
-import type { StoredMessage, AgentMode, ThreadWorktree } from '@agentpanel/core'
+import { ipcMain } from "electron";
+import { execSync } from "child_process";
+import { join } from "path";
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+import { IPC_CHANNELS } from "../../common/ipc-channels";
+import {
+  FileStorageAdapter,
+  readTraceEntries,
+  clearTraceFile,
+} from "@agentpanel/core";
+import type {
+  StoredMessage,
+  AgentMode,
+  ThreadWorktree,
+  Folder,
+} from "@agentpanel/core";
 
-const storage = new FileStorageAdapter()
+const storage = new FileStorageAdapter();
 
 // Reference to clearThreadSession — set by main/index.ts
-let clearSessionFn: ((threadId: string) => void) | null = null
-let getRunningIdsFn: (() => string[]) | null = null
+let clearSessionFn: ((threadId: string) => void) | null = null;
+let getRunningIdsFn: (() => string[]) | null = null;
 
 export function setThreadSessionClearer(fn: (threadId: string) => void): void {
-  clearSessionFn = fn
+  clearSessionFn = fn;
 }
 
 export function setRunningThreadsGetter(fn: () => string[]): void {
-  getRunningIdsFn = fn
+  getRunningIdsFn = fn;
 }
 
 export function registerThreadIpc(): void {
   ipcMain.handle(IPC_CHANNELS.THREADS_LIST, async () => {
-    return storage.listThreads()
-  })
+    return storage.listThreads();
+  });
 
   ipcMain.handle(IPC_CHANNELS.THREADS_GET_ACTIVE, async () => {
-    return storage.getActiveThreadId()
-  })
+    return storage.getActiveThreadId();
+  });
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_SET_ACTIVE, async (_event, threadId: string | null) => {
-    return storage.setActiveThreadId(threadId)
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_SET_ACTIVE,
+    async (_event, threadId: string | null) => {
+      return storage.setActiveThreadId(threadId);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_CREATE, async (_event, title?: string, model?: string, cwd?: string) => {
-    const thread = await storage.createThread(title, model, cwd)
-    return thread
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_CREATE,
+    async (_event, title?: string, model?: string, cwd?: string) => {
+      const thread = await storage.createThread(title, model, cwd);
+      return thread;
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.THREADS_GET, async (_event, threadId: string) => {
-    return storage.getThread(threadId)
-  })
+    return storage.getThread(threadId);
+  });
 
   // Git repo detection
-  ipcMain.handle(IPC_CHANNELS.CHECK_IS_GIT_REPO, async (_event, dirPath: string) => {
-    try {
-      execSync('git rev-parse --is-inside-work-tree', {
-        cwd: dirPath, encoding: 'utf-8', timeout: 3000,
-        stdio: ['pipe', 'pipe', 'pipe']
-      })
-      return true
-    } catch {
-      return false
-    }
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.CHECK_IS_GIT_REPO,
+    async (_event, dirPath: string) => {
+      try {
+        execSync("git rev-parse --is-inside-work-tree", {
+          cwd: dirPath,
+          encoding: "utf-8",
+          timeout: 3000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  );
 
   // Thread worktree creation
-  ipcMain.handle(IPC_CHANNELS.THREADS_CREATE_WORKTREE, async (_event, params: { threadId: string; sourceRepoPath: string }) => {
-    const { threadId, sourceRepoPath } = params
-    const shortId = threadId.slice(-7)
-    const branchName = `agentpanel/${shortId}`
-    const worktreeDir = join(homedir(), '.agentpanel', 'worktrees', threadId)
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_CREATE_WORKTREE,
+    async (_event, params: { threadId: string; sourceRepoPath: string }) => {
+      const { threadId, sourceRepoPath } = params;
+      const shortId = threadId.slice(-7);
+      const branchName = `agentpanel/${shortId}`;
+      const worktreeDir = join(homedir(), ".agentpanel", "worktrees", threadId);
 
-    mkdirSync(worktreeDir, { recursive: true })
+      mkdirSync(worktreeDir, { recursive: true });
 
-    execSync(`git worktree add -b "${branchName}" "${worktreeDir}"`, {
-      cwd: sourceRepoPath, encoding: 'utf-8', timeout: 30000,
-      stdio: ['pipe', 'pipe', 'pipe']
-    })
+      execSync(`git worktree add -b "${branchName}" "${worktreeDir}"`, {
+        cwd: sourceRepoPath,
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
 
-    const worktreeData: ThreadWorktree = {
-      path: worktreeDir,
-      branch: branchName,
-      sourceRepoPath
-    }
+      const worktreeData: ThreadWorktree = {
+        path: worktreeDir,
+        branch: branchName,
+        sourceRepoPath,
+      };
 
-    await storage.updateThread(threadId, { worktree: worktreeData, cwd: worktreeDir })
-    return worktreeData
-  })
+      await storage.updateThread(threadId, {
+        worktree: worktreeData,
+        cwd: worktreeDir,
+      });
+      return worktreeData;
+    },
+  );
 
   // Thread worktree cleanup
-  ipcMain.handle(IPC_CHANNELS.THREADS_CLEANUP_WORKTREE, async (_event, threadId: string) => {
-    const thread = await storage.getThread(threadId)
-    if (!thread?.worktree) return
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_CLEANUP_WORKTREE,
+    async (_event, threadId: string) => {
+      const thread = await storage.getThread(threadId);
+      if (!thread?.worktree) return;
 
-    const { sourceRepoPath, path: worktreePath } = thread.worktree
+      const { sourceRepoPath, path: worktreePath } = thread.worktree;
 
-    try {
-      execSync(`git worktree remove "${worktreePath}" --force`, {
-        cwd: sourceRepoPath, encoding: 'utf-8', timeout: 10000,
-        stdio: ['pipe', 'pipe', 'pipe']
-      })
-    } catch {
-      // Worktree may already be removed
-    }
-
-    await storage.updateThread(threadId, { worktree: undefined })
-  })
-
-  ipcMain.handle(IPC_CHANNELS.THREADS_UPDATE, async (_event, threadId: string, updates: { title?: string; model?: string; cwd?: string; thinkingEffort?: 'low' | 'medium' | 'high' | 'max'; mode?: AgentMode; additionalCwds?: string[]; isGitRepo?: boolean; worktreeMode?: 'local' | 'worktree' }) => {
-    // Clear session on cwd or mode change
-    if (updates.cwd !== undefined || updates.mode !== undefined) {
-      clearSessionFn?.(threadId)
-    }
-    return storage.updateThread(threadId, updates)
-  })
-
-  ipcMain.handle(IPC_CHANNELS.THREADS_DELETE, async (_event, threadId: string) => {
-    // Clean up worktree if one exists
-    const thread = await storage.getThread(threadId)
-    if (thread?.worktree) {
       try {
-        execSync(`git worktree remove "${thread.worktree.path}" --force`, {
-          cwd: thread.worktree.sourceRepoPath, encoding: 'utf-8', timeout: 10000,
-          stdio: ['pipe', 'pipe', 'pipe']
-        })
+        execSync(`git worktree remove "${worktreePath}" --force`, {
+          cwd: sourceRepoPath,
+          encoding: "utf-8",
+          timeout: 10000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
       } catch {
         // Worktree may already be removed
       }
-    }
 
-    clearSessionFn?.(threadId)
-    return storage.deleteThread(threadId)
-  })
+      await storage.updateThread(threadId, { worktree: undefined });
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_LOAD_MESSAGES, async (_event, threadId: string) => {
-    return storage.loadMessages(threadId)
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_UPDATE,
+    async (
+      _event,
+      threadId: string,
+      updates: {
+        title?: string;
+        model?: string;
+        cwd?: string;
+        thinkingEffort?: "low" | "medium" | "high" | "max";
+        mode?: AgentMode;
+        additionalCwds?: string[];
+        isGitRepo?: boolean;
+        worktreeMode?: "local" | "worktree";
+      },
+    ) => {
+      // Clear session on cwd or mode change
+      if (updates.cwd !== undefined || updates.mode !== undefined) {
+        clearSessionFn?.(threadId);
+      }
+      return storage.updateThread(threadId, updates);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_SAVE_MESSAGES, async (_event, threadId: string, messages: StoredMessage[]) => {
-    return storage.saveMessages(threadId, messages)
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_DELETE,
+    async (_event, threadId: string) => {
+      // Clean up worktree if one exists
+      const thread = await storage.getThread(threadId);
+      if (thread?.worktree) {
+        try {
+          execSync(`git worktree remove "${thread.worktree.path}" --force`, {
+            cwd: thread.worktree.sourceRepoPath,
+            encoding: "utf-8",
+            timeout: 10000,
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+        } catch {
+          // Worktree may already be removed
+        }
+      }
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_READ_TRACE, (_event, threadId: string) => {
-    return readTraceEntries(threadId)
-  })
+      clearSessionFn?.(threadId);
+      return storage.deleteThread(threadId);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.THREADS_CLEAR_TRACE, (_event, threadId: string) => {
-    clearTraceFile(threadId)
-  })
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_LOAD_MESSAGES,
+    async (_event, threadId: string) => {
+      return storage.loadMessages(threadId);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_SAVE_MESSAGES,
+    async (_event, threadId: string, messages: StoredMessage[]) => {
+      return storage.saveMessages(threadId, messages);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_READ_TRACE,
+    (_event, threadId: string) => {
+      return readTraceEntries(threadId);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.THREADS_CLEAR_TRACE,
+    (_event, threadId: string) => {
+      clearTraceFile(threadId);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.THREADS_RUNNING, () => {
-    return getRunningIdsFn?.() ?? []
-  })
+    return getRunningIdsFn?.() ?? [];
+  });
+
+  // Folders
+  ipcMain.handle(IPC_CHANNELS.FOLDERS_LIST, async () => {
+    return storage.listFolders();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.FOLDERS_ADD,
+    async (_event, path: string, name?: string) => {
+      return storage.addFolder(path, name);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.FOLDERS_REMOVE,
+    async (_event, folderId: string) => {
+      return storage.removeFolder(folderId);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.FOLDERS_UPDATE,
+    async (_event, folderId: string, updates: Partial<Folder>) => {
+      return storage.updateFolder(folderId, updates);
+    },
+  );
 }
 
 export function unregisterThreadIpc(): void {
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_LIST)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_GET_ACTIVE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_SET_ACTIVE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CREATE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_GET)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_UPDATE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_DELETE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_LOAD_MESSAGES)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_SAVE_MESSAGES)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_READ_TRACE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CLEAR_TRACE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_RUNNING)
-  ipcMain.removeHandler(IPC_CHANNELS.CHECK_IS_GIT_REPO)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CREATE_WORKTREE)
-  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CLEANUP_WORKTREE)
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_LIST);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_GET_ACTIVE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_SET_ACTIVE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CREATE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_GET);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_UPDATE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_DELETE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_LOAD_MESSAGES);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_SAVE_MESSAGES);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_READ_TRACE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CLEAR_TRACE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_RUNNING);
+  ipcMain.removeHandler(IPC_CHANNELS.CHECK_IS_GIT_REPO);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CREATE_WORKTREE);
+  ipcMain.removeHandler(IPC_CHANNELS.THREADS_CLEANUP_WORKTREE);
+  ipcMain.removeHandler(IPC_CHANNELS.FOLDERS_LIST);
+  ipcMain.removeHandler(IPC_CHANNELS.FOLDERS_ADD);
+  ipcMain.removeHandler(IPC_CHANNELS.FOLDERS_REMOVE);
+  ipcMain.removeHandler(IPC_CHANNELS.FOLDERS_UPDATE);
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { IPC_CHANNELS } from "../common/ipc-channels";
-import type { AgentMode } from "@agentpanel/core";
+import type { AgentMode, Folder } from "@agentpanel/core";
 
 export type ElectronAPI = typeof api;
 
@@ -191,6 +191,19 @@ const api = {
     ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_DISCONNECT),
   claudeGetConnection: (): Promise<unknown> =>
     ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_GET_CONNECTION),
+
+  // Folders
+  foldersList: (): Promise<Folder[]> =>
+    ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_LIST),
+  foldersAdd: (path: string, name?: string): Promise<Folder> =>
+    ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_ADD, path, name),
+  foldersRemove: (folderId: string): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_REMOVE, folderId),
+  foldersUpdate: (
+    folderId: string,
+    updates: Partial<Folder>,
+  ): Promise<Folder | null> =>
+    ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_UPDATE, folderId, updates),
 
   // Threads / sessions
   threadsList: () => ipcRenderer.invoke(IPC_CHANNELS.THREADS_LIST),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
-import { normalizeMode, AGENT_MODES, type AgentMode } from './utils/modes'
-import type { ImageAttachment } from '@agentpanel/ui'
+import { useState, useCallback, useRef, useEffect } from "react";
+import { normalizeMode, AGENT_MODES, type AgentMode } from "./utils/modes";
+import type { ImageAttachment } from "@agentpanel/ui";
 import {
   Sidebar,
   ChatView,
@@ -16,17 +16,18 @@ import {
   ModelSelector,
   ModeToggle,
   WorktreeToggle,
-} from '@agentpanel/ui'
+} from "@agentpanel/ui";
 
-import { Group, Panel, Separator } from 'react-resizable-panels'
-import { useChat } from './hooks/useChat'
-import { useThreads } from './hooks/useThreads'
-import { useGitHub } from './hooks/useGitHub'
-import { useClaude } from './hooks/useClaude'
-import { usePreview } from './hooks/usePreview'
-import { ConnectGitHubDialog } from './components/ConnectGitHubDialog'
-import { ConnectClaudeDialog } from './components/ConnectClaudeDialog'
-import { SettingsDialog } from './components/SettingsDialog'
+import { Group, Panel, Separator } from "react-resizable-panels";
+import { useChat } from "./hooks/useChat";
+import { useThreads } from "./hooks/useThreads";
+import { useFolders } from "./hooks/useFolders";
+import { useGitHub } from "./hooks/useGitHub";
+import { useClaude } from "./hooks/useClaude";
+import { usePreview } from "./hooks/usePreview";
+import { ConnectGitHubDialog } from "./components/ConnectGitHubDialog";
+import { ConnectClaudeDialog } from "./components/ConnectClaudeDialog";
+import { SettingsDialog } from "./components/SettingsDialog";
 
 export default function App(): React.ReactElement {
   const {
@@ -37,7 +38,9 @@ export default function App(): React.ReactElement {
     createThread,
     deleteThread,
     refreshThreads,
-  } = useThreads()
+  } = useThreads();
+
+  const { folders, addFolder, removeFolder, updateFolder } = useFolders();
 
   const {
     messages,
@@ -56,234 +59,246 @@ export default function App(): React.ReactElement {
     runningThreadIds,
     threadNotifications,
     sessionTools,
-  } = useChat(activeThreadId, { onThreadUpdated: refreshThreads })
+  } = useChat(activeThreadId, { onThreadUpdated: refreshThreads });
 
-  const github = useGitHub()
-  const claude = useClaude()
-  const { preview, openUrl, openMarkdown, openArtifactEditor, close: closePreview } = usePreview()
-  const { latestTodoData, showTaskPanel, setShowTaskPanel } = useTodoData(messages)
+  const github = useGitHub();
+  const claude = useClaude();
+  const {
+    preview,
+    openUrl,
+    openMarkdown,
+    openArtifactEditor,
+    close: closePreview,
+  } = usePreview();
+  const { latestTodoData, showTaskPanel, setShowTaskPanel } =
+    useTodoData(messages);
 
-  const [showClaudeDialog, setShowClaudeDialog] = useState(false)
-  const [showGitHubDialog, setShowGitHubDialog] = useState(false)
-  const [showSettingsDialog, setShowSettingsDialog] = useState(false)
-  const [pendingMode, setPendingMode] = useState<AgentMode>()
-  const [pendingAdditionalCwds, setPendingAdditionalCwds] = useState<string[]>([])
-  const [homeDir, setHomeDir] = useState('')
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const [modelPickerOpen, setModelPickerOpen] = useState(false)
-  const inputRef = useRef<InputBarRef | null>(null)
-  const draftsRef = useRef<Map<string, string>>(new Map())
-  const prevActiveThreadIdRef = useRef<string | null>(null)
+  const [showClaudeDialog, setShowClaudeDialog] = useState(false);
+  const [showGitHubDialog, setShowGitHubDialog] = useState(false);
+  const [showSettingsDialog, setShowSettingsDialog] = useState(false);
+  const [pendingMode, setPendingMode] = useState<AgentMode>();
+  const [pendingAdditionalCwds, setPendingAdditionalCwds] = useState<string[]>(
+    [],
+  );
+  const [homeDir, setHomeDir] = useState("");
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const inputRef = useRef<InputBarRef | null>(null);
+  const draftsRef = useRef<Map<string, string>>(new Map());
+  const prevActiveThreadIdRef = useRef<string | null>(null);
 
   // Fetch home directory
   useEffect(() => {
-    window.api.getHomeDirectory().then(setHomeDir)
-  }, [])
+    window.api.getHomeDirectory().then(setHomeDir);
+  }, []);
 
   // Save/restore draft input text when switching threads
   useEffect(() => {
-    const prev = prevActiveThreadIdRef.current
+    const prev = prevActiveThreadIdRef.current;
     if (prev && prev !== activeThreadId) {
-      const text = inputRef.current?.getText() ?? ''
-      if (text) draftsRef.current.set(prev, text)
-      else draftsRef.current.delete(prev)
+      const text = inputRef.current?.getText() ?? "";
+      if (text) draftsRef.current.set(prev, text);
+      else draftsRef.current.delete(prev);
     }
-    prevActiveThreadIdRef.current = activeThreadId
+    prevActiveThreadIdRef.current = activeThreadId;
     if (activeThreadId) {
-      inputRef.current?.prefill(draftsRef.current.get(activeThreadId) ?? '')
+      inputRef.current?.prefill(draftsRef.current.get(activeThreadId) ?? "");
     }
-  }, [activeThreadId])
+  }, [activeThreadId]);
 
   const handleThreadClick = useCallback(
     async (threadId: string) => {
-      closePreview()
-      await setActiveThreadId(threadId)
+      closePreview();
+      await setActiveThreadId(threadId);
     },
     [setActiveThreadId, closePreview],
-  )
+  );
 
-  const handleCreateThread = useCallback(async () => {
-    const result = await window.api.selectDirectory()
-    if (result.canceled || !result.path) return
-    const thread = await createThread('New chat', undefined, result.path)
-    // Detect git repo and set default worktree mode
-    const isGit = await window.api.checkIsGitRepo(result.path)
+  const handleAddFolder = useCallback(async () => {
+    const result = await window.api.selectDirectory();
+    if (result.canceled || !result.path) return;
+    const folder = await addFolder(result.path);
+    // Detect git repo
+    const isGit = await window.api.checkIsGitRepo(result.path);
     if (isGit) {
-      await window.api.threadsUpdate(thread.id, { isGitRepo: true, worktreeMode: 'local' })
-      await refreshThreads()
+      await updateFolder(folder.id, { isGitRepo: true });
     }
-    await setActiveThreadId(thread.id)
-    inputRef.current?.focus()
-  }, [createThread, setActiveThreadId, refreshThreads])
+  }, [addFolder, updateFolder]);
+
+  const handleToggleFolderCollapsed = useCallback(
+    (folderId: string, collapsed: boolean) =>
+      updateFolder(folderId, { collapsed }),
+    [updateFolder],
+  );
+
+  const handleCreateThreadInFolder = useCallback(
+    async (folderId: string) => {
+      const folder = folders.find((f) => f.id === folderId);
+      if (!folder) return;
+      const thread = await createThread("New chat", undefined, folder.path);
+      // Use folder's git repo info
+      if (folder.isGitRepo) {
+        await window.api.threadsUpdate(thread.id, {
+          isGitRepo: true,
+          worktreeMode: "local",
+        });
+        await refreshThreads();
+      }
+      await setActiveThreadId(thread.id);
+      inputRef.current?.focus();
+    },
+    [folders, createThread, setActiveThreadId, refreshThreads],
+  );
 
   const handleDeleteThread = useCallback(
     async (id: string) => {
-      draftsRef.current.delete(id)
-      await deleteThread(id)
+      draftsRef.current.delete(id);
+      await deleteThread(id);
     },
     [deleteThread],
-  )
+  );
 
   const handleSend = useCallback(
     async (prompt: string, images?: ImageAttachment[]) => {
-      let threadId = activeThreadId
-      if (!threadId) {
-        const result = await window.api.selectDirectory()
-        if (result.canceled || !result.path) return
-        const thread = await createThread('New chat', undefined, result.path)
-        threadId = thread.id
-        const updates: Record<string, unknown> = {}
-        if (pendingMode) {
-          updates.mode = pendingMode
-          setPendingMode(undefined)
-        }
-        if (pendingAdditionalCwds.length > 0) {
-          updates.additionalCwds = pendingAdditionalCwds
-          setPendingAdditionalCwds([])
-        }
-        // Detect git repo
-        const isGit = await window.api.checkIsGitRepo(result.path)
-        if (isGit) {
-          updates.isGitRepo = true
-          updates.worktreeMode = 'local'
-        }
-        if (Object.keys(updates).length > 0) {
-          await window.api.threadsUpdate(
-            threadId,
-            updates as Parameters<typeof window.api.threadsUpdate>[1],
-          )
-        }
-      }
-      await sendMessage(prompt, threadId, images)
+      const threadId = activeThreadId;
+      if (!threadId) return; // Must create a thread in a folder first
+      await sendMessage(prompt, threadId, images);
     },
-    [activeThreadId, createThread, sendMessage, pendingMode, pendingAdditionalCwds],
-  )
+    [activeThreadId, sendMessage],
+  );
 
   const handleModelChange = useCallback(
     async (model: string) => {
-      if (!activeThreadId) return
-      await window.api.threadsUpdate(activeThreadId, { model })
-      await refreshThreads()
+      if (!activeThreadId) return;
+      await window.api.threadsUpdate(activeThreadId, { model });
+      await refreshThreads();
     },
     [activeThreadId, refreshThreads],
-  )
+  );
 
   const handleThinkingEffortChange = useCallback(
     async (effort: string) => {
-      if (!activeThreadId) return
+      if (!activeThreadId) return;
       await window.api.threadsUpdate(activeThreadId, {
-        thinkingEffort: effort as 'low' | 'medium' | 'high' | 'max',
-      })
-      await refreshThreads()
+        thinkingEffort: effort as "low" | "medium" | "high" | "max",
+      });
+      await refreshThreads();
     },
     [activeThreadId, refreshThreads],
-  )
+  );
 
   const handleAddDirectory = useCallback(async () => {
-    const result = await window.api.selectDirectory()
-    if (result.canceled || !result.path) return
-    const newPath = result.path
+    const result = await window.api.selectDirectory();
+    if (result.canceled || !result.path) return;
+    const newPath = result.path;
     if (activeThreadId) {
-      const currentCwds = activeThread?.additionalCwds ?? []
-      if (currentCwds.includes(newPath) || activeThread?.cwd === newPath) return
+      const currentCwds = activeThread?.additionalCwds ?? [];
+      if (currentCwds.includes(newPath) || activeThread?.cwd === newPath)
+        return;
       await window.api.threadsUpdate(activeThreadId, {
         additionalCwds: [...currentCwds, newPath],
-      })
-      await refreshThreads()
+      });
+      await refreshThreads();
     } else {
-      setPendingAdditionalCwds((prev) => (prev.includes(newPath) ? prev : [...prev, newPath]))
+      setPendingAdditionalCwds((prev) =>
+        prev.includes(newPath) ? prev : [...prev, newPath],
+      );
     }
-  }, [activeThreadId, activeThread, refreshThreads])
+  }, [activeThreadId, activeThread, refreshThreads]);
 
   const handleRemoveDirectory = useCallback(
     async (path: string) => {
       if (activeThreadId) {
-        const currentCwds = activeThread?.additionalCwds ?? []
+        const currentCwds = activeThread?.additionalCwds ?? [];
         await window.api.threadsUpdate(activeThreadId, {
           additionalCwds: currentCwds.filter((d) => d !== path),
-        })
-        await refreshThreads()
+        });
+        await refreshThreads();
       } else {
-        setPendingAdditionalCwds((prev) => prev.filter((d) => d !== path))
+        setPendingAdditionalCwds((prev) => prev.filter((d) => d !== path));
       }
     },
     [activeThreadId, activeThread, refreshThreads],
-  )
+  );
 
   const handleModeChange = useCallback(
     async (mode: AgentMode) => {
       if (!activeThreadId) {
-        setPendingMode(mode)
-        return
+        setPendingMode(mode);
+        return;
       }
-      await window.api.threadsUpdate(activeThreadId, { mode })
-      await refreshThreads()
+      await window.api.threadsUpdate(activeThreadId, { mode });
+      await refreshThreads();
     },
     [activeThreadId, refreshThreads],
-  )
+  );
 
   const handleWorktreeModeChange = useCallback(
-    async (mode: 'local' | 'worktree') => {
-      if (!activeThreadId) return
-      await window.api.threadsUpdate(activeThreadId, { worktreeMode: mode })
-      await refreshThreads()
+    async (mode: "local" | "worktree") => {
+      if (!activeThreadId) return;
+      await window.api.threadsUpdate(activeThreadId, { worktreeMode: mode });
+      await refreshThreads();
     },
     [activeThreadId, refreshThreads],
-  )
+  );
 
   // Ctrl+Tab to cycle modes
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.shiftKey) && e.key === 'Tab') {
-        e.preventDefault()
-        e.stopPropagation()
-        if (isStreaming) return
+      if ((e.ctrlKey || e.shiftKey) && e.key === "Tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (isStreaming) return;
         const currentMode = activeThread?.mode
           ? normalizeMode(activeThread.mode)
-          : (pendingMode ?? 'default')
-        const currentIndex = AGENT_MODES.indexOf(currentMode)
-        const nextIndex = (currentIndex + 1) % AGENT_MODES.length
-        handleModeChange(AGENT_MODES[nextIndex])
+          : (pendingMode ?? "default");
+        const currentIndex = AGENT_MODES.indexOf(currentMode);
+        const nextIndex = (currentIndex + 1) % AGENT_MODES.length;
+        handleModeChange(AGENT_MODES[nextIndex]);
       }
-    }
-    document.addEventListener('keydown', handler, { capture: true })
-    return () => document.removeEventListener('keydown', handler, { capture: true })
-  }, [activeThread, pendingMode, isStreaming, handleModeChange])
+    };
+    document.addEventListener("keydown", handler, { capture: true });
+    return () =>
+      document.removeEventListener("keydown", handler, { capture: true });
+  }, [activeThread, pendingMode, isStreaming, handleModeChange]);
 
   // Handle notification click -> activate thread
   useEffect(() => {
     window.api.onThreadActivate(({ threadId }: { threadId: string }) => {
-      handleThreadClick(threadId)
-    })
-    return () => window.api.removeAllListeners('chat:thread-activate')
-  }, [handleThreadClick])
+      handleThreadClick(threadId);
+    });
+    return () => window.api.removeAllListeners("chat:thread-activate");
+  }, [handleThreadClick]);
 
   // Cmd+B to toggle sidebar
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'b') {
-        e.preventDefault()
-        setSidebarCollapsed((prev) => !prev)
+      if ((e.metaKey || e.ctrlKey) && e.key === "b") {
+        e.preventDefault();
+        setSidebarCollapsed((prev) => !prev);
       }
-    }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [])
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
 
   // Cmd+P to open model picker (via main process menu)
   useEffect(() => {
-    window.api.onOpenModelPicker(() => setModelPickerOpen((v) => !v))
-    return () => window.api.removeAllListeners('ui:open-model-picker')
-  }, [])
+    window.api.onOpenModelPicker(() => setModelPickerOpen((v) => !v));
+    return () => window.api.removeAllListeners("ui:open-model-picker");
+  }, []);
 
   // Auto-open Claude auth dialog on auth failure
   useEffect(() => {
-    const handler = () => setShowClaudeDialog(true)
-    window.addEventListener('claude:auth-failed', handler)
-    return () => window.removeEventListener('claude:auth-failed', handler)
-  }, [])
+    const handler = () => setShowClaudeDialog(true);
+    window.addEventListener("claude:auth-failed", handler);
+    return () => window.removeEventListener("claude:auth-failed", handler);
+  }, []);
 
-  const toggleSidebar = useCallback(() => setSidebarCollapsed((prev) => !prev), [])
+  const toggleSidebar = useCallback(
+    () => setSidebarCollapsed((prev) => !prev),
+    [],
+  );
 
   return (
     <div className="flex h-screen">
@@ -293,30 +308,35 @@ export default function App(): React.ReactElement {
       >
         <Sidebar
           threads={threads}
+          folders={folders}
           activeThreadId={activeThreadId}
           onThreadClick={handleThreadClick}
-          onCreateThread={handleCreateThread}
+          onCreateThreadInFolder={handleCreateThreadInFolder}
+          onAddFolder={handleAddFolder}
+          onRemoveFolder={removeFolder}
+          onToggleFolderCollapsed={handleToggleFolderCollapsed}
           onDeleteThread={handleDeleteThread}
           onToggleSidebar={toggleSidebar}
           onSettingsClick={() => setShowSettingsDialog(true)}
           runningThreadIds={runningThreadIds}
           threadNotifications={threadNotifications}
-
         />
       </div>
 
       <Group
-        key={preview.isOpen ? 'split' : 'full'}
+        key={preview.isOpen ? "split" : "full"}
         orientation="horizontal"
         className="flex-1 min-h-0"
       >
         <Panel defaultSize={preview.isOpen ? 70 : 100} minSize={30}>
           <div className="flex flex-col h-full bg-[#0f0f0f] rounded-l-xl overflow-hidden">
-            {sidebarCollapsed && <div className="drag-region h-7 flex-shrink-0" />}
+            {sidebarCollapsed && (
+              <div className="drag-region h-7 flex-shrink-0" />
+            )}
 
             {/* Top bar */}
             <div
-              className={`drag-region flex-shrink-0 flex items-end justify-between px-4 pb-1.5 ${sidebarCollapsed ? '' : 'h-11'}`}
+              className={`drag-region flex-shrink-0 flex items-end justify-between px-4 pb-1.5 ${sidebarCollapsed ? "" : "h-11"}`}
             >
               <div className="flex items-center">
                 {sidebarCollapsed && (
@@ -345,24 +365,36 @@ export default function App(): React.ReactElement {
                 <button
                   onClick={() => setShowClaudeDialog(true)}
                   className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[#2a2a2a]"
-                  title={claude.isConnected ? 'Claude connected' : 'Connect Claude'}
+                  title={
+                    claude.isConnected ? "Claude connected" : "Connect Claude"
+                  }
                 >
                   <div
-                    className={`w-1.5 h-1.5 rounded-full ${claude.isConnected ? 'bg-green-500' : 'bg-gray-600'}`}
+                    className={`w-1.5 h-1.5 rounded-full ${claude.isConnected ? "bg-green-500" : "bg-gray-600"}`}
                   />
-                  <span className={claude.isConnected ? 'text-gray-400' : 'text-gray-600'}>
+                  <span
+                    className={
+                      claude.isConnected ? "text-gray-400" : "text-gray-600"
+                    }
+                  >
                     Claude
                   </span>
                 </button>
                 <button
                   onClick={() => setShowGitHubDialog(true)}
                   className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[#2a2a2a]"
-                  title={github.isConnected ? 'GitHub connected' : 'Connect GitHub'}
+                  title={
+                    github.isConnected ? "GitHub connected" : "Connect GitHub"
+                  }
                 >
                   <div
-                    className={`w-1.5 h-1.5 rounded-full ${github.isConnected ? 'bg-green-500' : 'bg-gray-600'}`}
+                    className={`w-1.5 h-1.5 rounded-full ${github.isConnected ? "bg-green-500" : "bg-gray-600"}`}
                   />
-                  <span className={github.isConnected ? 'text-gray-400' : 'text-gray-600'}>
+                  <span
+                    className={
+                      github.isConnected ? "text-gray-400" : "text-gray-600"
+                    }
+                  >
                     GitHub
                   </span>
                 </button>
@@ -372,7 +404,9 @@ export default function App(): React.ReactElement {
             {/* Chat info bar */}
             <ChatInfoBar
               primaryCwd={activeThread?.cwd}
-              additionalCwds={activeThread?.additionalCwds ?? pendingAdditionalCwds}
+              additionalCwds={
+                activeThread?.additionalCwds ?? pendingAdditionalCwds
+              }
               onAddDirectory={handleAddDirectory}
               onRemoveDirectory={handleRemoveDirectory}
               sessionStats={sessionStats}
@@ -426,7 +460,11 @@ export default function App(): React.ReactElement {
                   onOpenChange={setModelPickerOpen}
                 />
                 <ModeToggle
-                  mode={activeThread?.mode ? normalizeMode(activeThread.mode) : pendingMode}
+                  mode={
+                    activeThread?.mode
+                      ? normalizeMode(activeThread.mode)
+                      : pendingMode
+                  }
                   onModeChange={handleModeChange}
                   disabled={isStreaming}
                 />
@@ -447,7 +485,10 @@ export default function App(): React.ReactElement {
 
       {/* Permission dialog */}
       {permissionRequest && (
-        <PermissionDialog request={permissionRequest} onRespond={respondPermission} />
+        <PermissionDialog
+          request={permissionRequest}
+          onRespond={respondPermission}
+        />
       )}
 
       {/* Claude connect dialog */}
@@ -485,5 +526,5 @@ export default function App(): React.ReactElement {
         onClose={() => setShowSettingsDialog(false)}
       />
     </div>
-  )
+  );
 }

--- a/packages/desktop/src/renderer/hooks/useFolders.ts
+++ b/packages/desktop/src/renderer/hooks/useFolders.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Folder } from "@agentpanel/core";
+
+interface UseFoldersReturn {
+  folders: Folder[];
+  addFolder: (path: string, name?: string) => Promise<Folder>;
+  removeFolder: (folderId: string) => Promise<void>;
+  updateFolder: (folderId: string, updates: Partial<Folder>) => Promise<void>;
+  refreshFolders: () => Promise<void>;
+}
+
+export function useFolders(): UseFoldersReturn {
+  const [folders, setFolders] = useState<Folder[]>([]);
+
+  const refreshFolders = useCallback(async () => {
+    const list = await window.api.foldersList();
+    setFolders(list);
+  }, []);
+
+  useEffect(() => {
+    refreshFolders();
+  }, [refreshFolders]);
+
+  const addFolder = useCallback(
+    async (path: string, name?: string) => {
+      const folder = await window.api.foldersAdd(path, name);
+      await refreshFolders();
+      return folder;
+    },
+    [refreshFolders],
+  );
+
+  const removeFolder = useCallback(
+    async (folderId: string) => {
+      await window.api.foldersRemove(folderId);
+      await refreshFolders();
+    },
+    [refreshFolders],
+  );
+
+  const updateFolder = useCallback(
+    async (folderId: string, updates: Partial<Folder>) => {
+      await window.api.foldersUpdate(folderId, updates);
+      await refreshFolders();
+    },
+    [refreshFolders],
+  );
+
+  return { folders, addFolder, removeFolder, updateFolder, refreshFolders };
+}

--- a/packages/ui/src/__tests__/Sidebar.test.tsx
+++ b/packages/ui/src/__tests__/Sidebar.test.tsx
@@ -1,68 +1,79 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { Sidebar } from '../components/Sidebar'
-import type { Thread } from '@agentpanel/core'
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Sidebar } from "../components/Sidebar";
+import type { Thread, Folder } from "@agentpanel/core";
 
-function makeThread(id: string, title: string): Thread {
-  return { id, title, createdAt: Date.now(), updatedAt: Date.now() }
+function makeThread(id: string, title: string, cwd?: string): Thread {
+  return { id, title, createdAt: Date.now(), updatedAt: Date.now(), cwd };
 }
 
-describe('Sidebar', () => {
+function makeFolder(id: string, name: string, path: string): Folder {
+  return { id, name, path, createdAt: Date.now() };
+}
+
+describe("Sidebar", () => {
   const defaultProps = {
-    threads: [makeThread('t1', 'Thread One'), makeThread('t2', 'Thread Two')],
-    activeThreadId: 't1',
+    threads: [
+      makeThread("t1", "Thread One", "/proj"),
+      makeThread("t2", "Thread Two", "/proj"),
+    ],
+    folders: [makeFolder("f1", "proj", "/proj")],
+    activeThreadId: "t1",
     onThreadClick: vi.fn(),
-    onCreateThread: vi.fn(),
+    onCreateThreadInFolder: vi.fn(),
+    onAddFolder: vi.fn(),
+    onRemoveFolder: vi.fn(),
+    onToggleFolderCollapsed: vi.fn(),
     onDeleteThread: vi.fn(),
     onToggleSidebar: vi.fn(),
     onSettingsClick: vi.fn(),
     runningThreadIds: [] as string[],
-    threadNotifications: new Map<string, string>()
-  }
+    threadNotifications: new Map<string, string>(),
+  };
 
   afterEach(() => {
-    cleanup()
-    vi.clearAllMocks()
-  })
+    cleanup();
+    vi.clearAllMocks();
+  });
 
-  it('renders the AgentPanel branding', () => {
-    render(<Sidebar {...defaultProps} />)
-    expect(screen.getByText('Agent')).toBeInTheDocument()
-    expect(screen.getByText('Panel')).toBeInTheDocument()
-  })
+  it("renders the AgentPanel branding", () => {
+    render(<Sidebar {...defaultProps} />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("Panel")).toBeInTheDocument();
+  });
 
-  it('renders thread titles', () => {
-    render(<Sidebar {...defaultProps} />)
-    expect(screen.getByText('Thread One')).toBeInTheDocument()
-    expect(screen.getByText('Thread Two')).toBeInTheDocument()
-  })
+  it("renders thread titles under folder", () => {
+    render(<Sidebar {...defaultProps} />);
+    expect(screen.getByText("Thread One")).toBeInTheDocument();
+    expect(screen.getByText("Thread Two")).toBeInTheDocument();
+  });
 
-  it('calls onSettingsClick when settings button is clicked', async () => {
-    const user = userEvent.setup()
-    render(<Sidebar {...defaultProps} />)
-    await user.click(screen.getByTitle('Settings'))
-    expect(defaultProps.onSettingsClick).toHaveBeenCalledOnce()
-  })
+  it("calls onSettingsClick when settings button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Sidebar {...defaultProps} />);
+    await user.click(screen.getByTitle("Settings"));
+    expect(defaultProps.onSettingsClick).toHaveBeenCalledOnce();
+  });
 
-  it('calls onToggleSidebar when collapse button is clicked', async () => {
-    const user = userEvent.setup()
-    render(<Sidebar {...defaultProps} />)
-    await user.click(screen.getByTitle('Collapse sidebar'))
-    expect(defaultProps.onToggleSidebar).toHaveBeenCalledOnce()
-  })
+  it("calls onToggleSidebar when collapse button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Sidebar {...defaultProps} />);
+    await user.click(screen.getByTitle("Collapse sidebar"));
+    expect(defaultProps.onToggleSidebar).toHaveBeenCalledOnce();
+  });
 
-  it('calls onCreateThread when new thread button is clicked', async () => {
-    const user = userEvent.setup()
-    render(<Sidebar {...defaultProps} />)
-    await user.click(screen.getByTitle('New thread'))
-    expect(defaultProps.onCreateThread).toHaveBeenCalledOnce()
-  })
+  it("calls onAddFolder when add folder button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Sidebar {...defaultProps} />);
+    await user.click(screen.getByTitle("Add folder"));
+    expect(defaultProps.onAddFolder).toHaveBeenCalledOnce();
+  });
 
-  it('calls onThreadClick when a thread is clicked', async () => {
-    const user = userEvent.setup()
-    render(<Sidebar {...defaultProps} />)
-    await user.click(screen.getByText('Thread Two'))
-    expect(defaultProps.onThreadClick).toHaveBeenCalledWith('t2')
-  })
-})
+  it("calls onThreadClick when a thread is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Sidebar {...defaultProps} />);
+    await user.click(screen.getByText("Thread Two"));
+    expect(defaultProps.onThreadClick).toHaveBeenCalledWith("t2");
+  });
+});

--- a/packages/ui/src/__tests__/ThreadList.test.tsx
+++ b/packages/ui/src/__tests__/ThreadList.test.tsx
@@ -1,62 +1,149 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { ThreadList } from '../components/ThreadList'
-import type { Thread } from '@agentpanel/core'
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThreadList } from "../components/ThreadList";
+import type { Thread, Folder } from "@agentpanel/core";
 
-function makeThread(id: string, title: string): Thread {
-  return { id, title, createdAt: Date.now(), updatedAt: Date.now() }
+function makeThread(id: string, title: string, cwd?: string): Thread {
+  return { id, title, createdAt: Date.now(), updatedAt: Date.now(), cwd };
+}
+
+function makeFolder(id: string, name: string, path: string): Folder {
+  return { id, name, path, createdAt: Date.now() };
 }
 
 const baseProps = {
   onThreadClick: vi.fn(),
-  onCreateThread: vi.fn(),
+  onCreateThreadInFolder: vi.fn(),
+  onAddFolder: vi.fn(),
+  onRemoveFolder: vi.fn(),
+  onToggleFolderCollapsed: vi.fn(),
   onDeleteThread: vi.fn(),
   runningThreadIds: [] as string[],
-  threadNotifications: new Map<string, string>()
-}
+  threadNotifications: new Map<string, string>(),
+};
 
-describe('ThreadList', () => {
-  afterEach(() => { cleanup(); vi.clearAllMocks() })
+describe("ThreadList", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
 
-  it('shows "No threads yet" when list is empty', () => {
-    render(<ThreadList {...baseProps} threads={[]} activeThreadId={null} />)
-    expect(screen.getByText('No threads yet')).toBeInTheDocument()
-  })
+  it("shows empty state when no folders", () => {
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={[]}
+        folders={[]}
+        activeThreadId={null}
+      />,
+    );
+    expect(screen.getByText("Add a folder")).toBeInTheDocument();
+  });
 
-  it('renders thread titles', () => {
-    const threads = [makeThread('a', 'Alpha'), makeThread('b', 'Beta')]
-    render(<ThreadList {...baseProps} threads={threads} activeThreadId={null} />)
-    expect(screen.getByText('Alpha')).toBeInTheDocument()
-    expect(screen.getByText('Beta')).toBeInTheDocument()
-  })
+  it("renders folder names", () => {
+    const folders = [makeFolder("f1", "my-project", "/home/user/my-project")];
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={[]}
+        folders={folders}
+        activeThreadId={null}
+      />,
+    );
+    expect(screen.getByText("my-project")).toBeInTheDocument();
+  });
 
-  it('highlights the active thread', () => {
-    const threads = [makeThread('a', 'Alpha'), makeThread('b', 'Beta')]
-    render(<ThreadList {...baseProps} threads={threads} activeThreadId="a" />)
-    const alphaEl = screen.getByText('Alpha').closest('div[class*="rounded-lg"]')!
-    expect(alphaEl.className).toContain('bg-[#2a2a2a]')
-    const betaEl = screen.getByText('Beta').closest('div[class*="rounded-lg"]')!
-    expect(betaEl.className).not.toContain('bg-[#2a2a2a]')
-  })
+  it("renders threads under their folder", () => {
+    const folders = [makeFolder("f1", "my-project", "/home/user/my-project")];
+    const threads = [makeThread("a", "Alpha", "/home/user/my-project")];
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={threads}
+        folders={folders}
+        activeThreadId={null}
+      />,
+    );
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
 
-  it('calls onThreadClick with correct id', async () => {
-    const user = userEvent.setup()
-    const threads = [makeThread('a', 'Alpha')]
-    render(<ThreadList {...baseProps} threads={threads} activeThreadId={null} />)
-    await user.click(screen.getByText('Alpha'))
-    expect(baseProps.onThreadClick).toHaveBeenCalledWith('a')
-  })
+  it('shows "No threads" for empty folders', () => {
+    const folders = [makeFolder("f1", "my-project", "/home/user/my-project")];
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={[]}
+        folders={folders}
+        activeThreadId={null}
+      />,
+    );
+    expect(screen.getByText("No threads")).toBeInTheDocument();
+  });
 
-  it('calls onCreateThread when new thread button is clicked', async () => {
-    const user = userEvent.setup()
-    render(<ThreadList {...baseProps} threads={[]} activeThreadId={null} />)
-    await user.click(screen.getByTitle('New thread'))
-    expect(baseProps.onCreateThread).toHaveBeenCalledOnce()
-  })
+  it("highlights the active thread", () => {
+    const folders = [makeFolder("f1", "proj", "/proj")];
+    const threads = [
+      makeThread("a", "Alpha", "/proj"),
+      makeThread("b", "Beta", "/proj"),
+    ];
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={threads}
+        folders={folders}
+        activeThreadId="a"
+      />,
+    );
+    const alphaEl = screen
+      .getByText("Alpha")
+      .closest('div[class*="rounded-lg"]')!;
+    expect(alphaEl.className).toContain("bg-[#2a2a2a]");
+    const betaEl = screen
+      .getByText("Beta")
+      .closest('div[class*="rounded-lg"]')!;
+    expect(betaEl.className).not.toContain("bg-[#2a2a2a]");
+  });
 
-  it('shows the Threads header', () => {
-    render(<ThreadList {...baseProps} threads={[]} activeThreadId={null} />)
-    expect(screen.getByText('Threads')).toBeInTheDocument()
-  })
-})
+  it("calls onThreadClick with correct id", async () => {
+    const user = userEvent.setup();
+    const folders = [makeFolder("f1", "proj", "/proj")];
+    const threads = [makeThread("a", "Alpha", "/proj")];
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={threads}
+        folders={folders}
+        activeThreadId={null}
+      />,
+    );
+    await user.click(screen.getByText("Alpha"));
+    expect(baseProps.onThreadClick).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onAddFolder when add folder button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={[]}
+        folders={[]}
+        activeThreadId={null}
+      />,
+    );
+    await user.click(screen.getByTitle("Add folder"));
+    expect(baseProps.onAddFolder).toHaveBeenCalledOnce();
+  });
+
+  it("shows the Threads header", () => {
+    render(
+      <ThreadList
+        {...baseProps}
+        threads={[]}
+        folders={[]}
+        activeThreadId={null}
+      />,
+    );
+    expect(screen.getByText("Threads")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -1,28 +1,36 @@
-import type { Thread } from '@agentpanel/core'
-import { ThreadList } from './ThreadList'
+import type { Thread, Folder } from "@agentpanel/core";
+import { ThreadList } from "./ThreadList";
 
 interface Props {
-  threads: Thread[]
-  activeThreadId: string | null
-  onThreadClick: (threadId: string) => void
-  onCreateThread: () => void
-  onDeleteThread: (threadId: string) => void
-  onToggleSidebar: () => void
-  onSettingsClick: () => void
-  runningThreadIds: string[]
-  threadNotifications: Map<string, string>
+  threads: Thread[];
+  folders: Folder[];
+  activeThreadId: string | null;
+  onThreadClick: (threadId: string) => void;
+  onCreateThreadInFolder: (folderId: string) => void;
+  onAddFolder: () => void;
+  onRemoveFolder: (folderId: string) => void;
+  onToggleFolderCollapsed: (folderId: string, collapsed: boolean) => void;
+  onDeleteThread: (threadId: string) => void;
+  onToggleSidebar: () => void;
+  onSettingsClick: () => void;
+  runningThreadIds: string[];
+  threadNotifications: Map<string, string>;
 }
 
 export function Sidebar({
   threads,
+  folders,
   activeThreadId,
   onThreadClick,
-  onCreateThread,
+  onCreateThreadInFolder,
+  onAddFolder,
+  onRemoveFolder,
+  onToggleFolderCollapsed,
   onDeleteThread,
   onToggleSidebar,
   onSettingsClick,
   runningThreadIds,
-  threadNotifications
+  threadNotifications,
 }: Props): React.ReactElement {
   return (
     <div className="flex-shrink-0 flex flex-col bg-[#0a0a0a] overflow-hidden w-[232px] min-w-[232px] h-full">
@@ -39,8 +47,18 @@ export function Sidebar({
             className="no-drag p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-[#1a1a1a] transition-colors"
             title="Collapse sidebar"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+              />
             </svg>
           </button>
         </div>
@@ -49,9 +67,13 @@ export function Sidebar({
         <div className="flex-1 flex flex-col min-h-0 border-t border-white/10 overflow-y-auto px-1 py-2">
           <ThreadList
             threads={threads}
+            folders={folders}
             activeThreadId={activeThreadId}
             onThreadClick={onThreadClick}
-            onCreateThread={onCreateThread}
+            onCreateThreadInFolder={onCreateThreadInFolder}
+            onAddFolder={onAddFolder}
+            onRemoveFolder={onRemoveFolder}
+            onToggleFolderCollapsed={onToggleFolderCollapsed}
             onDeleteThread={onDeleteThread}
             runningThreadIds={runningThreadIds}
             threadNotifications={threadNotifications}
@@ -65,14 +87,28 @@ export function Sidebar({
             className="no-drag w-full flex items-center gap-3 px-3 py-2 rounded-lg text-gray-500 hover:bg-[#1a1a1a] hover:text-gray-300 transition-colors text-sm"
             title="Settings"
           >
-            <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <svg
+              className="w-4 h-4 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
             </svg>
             <span>Settings</span>
           </button>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/packages/ui/src/components/ThreadList.tsx
+++ b/packages/ui/src/components/ThreadList.tsx
@@ -1,109 +1,346 @@
-import { useState } from 'react'
-import type { Thread } from '@agentpanel/core'
+import { useState, useMemo, useRef, useEffect } from "react";
+import type { Thread, Folder } from "@agentpanel/core";
 
 interface Props {
-  threads: Thread[]
-  activeThreadId: string | null
-  onThreadClick: (threadId: string) => void
-  onCreateThread: () => void
-  onDeleteThread: (threadId: string) => void
-  runningThreadIds: string[]
-  threadNotifications: Map<string, string>
+  threads: Thread[];
+  folders: Folder[];
+  activeThreadId: string | null;
+  onThreadClick: (threadId: string) => void;
+  onCreateThreadInFolder: (folderId: string) => void;
+  onAddFolder: () => void;
+  onRemoveFolder: (folderId: string) => void;
+  onToggleFolderCollapsed: (folderId: string, collapsed: boolean) => void;
+  onDeleteThread: (threadId: string) => void;
+  runningThreadIds: string[];
+  threadNotifications: Map<string, string>;
+}
+
+function FolderMenu({
+  onRemove,
+  onClose,
+}: {
+  onRemove: () => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-1 z-50 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-lg py-1 min-w-[140px]"
+    >
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+          onClose();
+        }}
+        className="w-full text-left px-3 py-1.5 text-xs text-gray-400 hover:text-red-400 hover:bg-[#2a2a2a] transition-colors"
+      >
+        Remove folder
+      </button>
+    </div>
+  );
+}
+
+function ThreadRow({
+  thread,
+  isActive,
+  isRunning,
+  notification,
+  confirmDelete,
+  onThreadClick,
+  onDeleteThread,
+  setConfirmDelete,
+}: {
+  thread: Thread;
+  isActive: boolean;
+  isRunning: boolean;
+  notification: string | undefined;
+  confirmDelete: string | null;
+  onThreadClick: (id: string) => void;
+  onDeleteThread: (id: string) => void;
+  setConfirmDelete: (id: string | null) => void;
+}) {
+  const isDeleting = confirmDelete === thread.id;
+
+  return (
+    <div
+      className={`group no-drag flex items-center gap-2 pl-7 pr-3 py-1.5 rounded-lg cursor-pointer transition-colors text-sm ${
+        isActive
+          ? "bg-[#2a2a2a] text-gray-200"
+          : "text-gray-400 hover:bg-[#1a1a1a] hover:text-gray-200"
+      }`}
+      onClick={() => onThreadClick(thread.id)}
+    >
+      {isRunning && (
+        <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
+      )}
+      <span className="flex-1 truncate">{thread.title}</span>
+      {notification && !isActive && (
+        <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+      )}
+      {isDeleting ? (
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            onClick={() => {
+              onDeleteThread(thread.id);
+              setConfirmDelete(null);
+            }}
+            className="text-xs text-red-400 hover:text-red-300 px-1"
+          >
+            Delete
+          </button>
+          <button
+            onClick={() => setConfirmDelete(null)}
+            className="text-xs text-gray-500 hover:text-gray-300 px-1"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setConfirmDelete(thread.id);
+          }}
+          className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-gray-600 hover:text-red-400 transition-all"
+          title="Delete thread"
+        >
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
 }
 
 export function ThreadList({
   threads,
+  folders,
   activeThreadId,
   onThreadClick,
-  onCreateThread,
+  onCreateThreadInFolder,
+  onAddFolder,
+  onRemoveFolder,
+  onToggleFolderCollapsed,
   onDeleteThread,
   runningThreadIds,
-  threadNotifications
+  threadNotifications,
 }: Props): React.ReactElement {
-  const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [menuOpenFolderId, setMenuOpenFolderId] = useState<string | null>(null);
+
+  // Group threads by folder path
+  const threadsByFolderPath = useMemo(() => {
+    const map = new Map<string, Thread[]>();
+    for (const thread of threads) {
+      if (!thread.cwd) continue;
+      const existing = map.get(thread.cwd) ?? [];
+      existing.push(thread);
+      map.set(thread.cwd, existing);
+    }
+    return map;
+  }, [threads]);
 
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2">
-        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Threads</span>
+        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+          Threads
+        </span>
         <button
-          onClick={onCreateThread}
+          onClick={onAddFolder}
           className="no-drag p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-[#1a1a1a] transition-colors"
-          title="New thread"
+          title="Add folder"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 4v16m8-8H4"
+            />
           </svg>
         </button>
       </div>
 
-      {/* Thread list */}
+      {/* Folder list */}
       <div className="flex-1 overflow-y-auto space-y-0.5 px-1">
-        {threads.length === 0 ? (
-          <p className="text-xs text-gray-600 py-4 px-3 text-center">No threads yet</p>
+        {folders.length === 0 ? (
+          <p className="text-xs text-gray-600 py-4 px-3 text-center">
+            No folders yet.{" "}
+            <button
+              onClick={onAddFolder}
+              className="text-gray-400 hover:text-gray-200 underline"
+            >
+              Add a folder
+            </button>{" "}
+            to get started.
+          </p>
         ) : (
-          threads.map((thread) => {
-            const isActive = thread.id === activeThreadId
-            const isRunning = runningThreadIds.includes(thread.id)
-            const notification = threadNotifications.get(thread.id)
-            const isDeleting = confirmDelete === thread.id
+          folders.map((folder) => {
+            const folderThreads = threadsByFolderPath.get(folder.path) ?? [];
+            const isCollapsed = folder.collapsed ?? false;
+            const isMenuOpen = menuOpenFolderId === folder.id;
 
             return (
-              <div
-                key={thread.id}
-                className={`group no-drag flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-sm ${
-                  isActive
-                    ? 'bg-[#2a2a2a] text-gray-200'
-                    : 'text-gray-400 hover:bg-[#1a1a1a] hover:text-gray-200'
-                }`}
-                onClick={() => onThreadClick(thread.id)}
-              >
-                {/* Running indicator */}
-                {isRunning && (
-                  <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
-                )}
+              <div key={folder.id}>
+                {/* Folder row */}
+                <div
+                  className="group no-drag flex items-center gap-1.5 px-2 py-1.5 rounded-lg cursor-pointer transition-colors text-sm text-gray-300 hover:bg-[#1a1a1a] relative"
+                  onClick={() =>
+                    onToggleFolderCollapsed(folder.id, !isCollapsed)
+                  }
+                >
+                  {/* Collapse chevron */}
+                  <svg
+                    className={`w-3 h-3 text-gray-500 flex-shrink-0 transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
 
-                {/* Title */}
-                <span className="flex-1 truncate">{thread.title}</span>
+                  {/* Folder icon */}
+                  <svg
+                    className="w-4 h-4 text-gray-500 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"
+                    />
+                  </svg>
 
-                {/* Notification badge */}
-                {notification && !isActive && (
-                  <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
-                )}
+                  {/* Folder name */}
+                  <span className="flex-1 truncate font-medium">
+                    {folder.name}
+                  </span>
 
-                {/* Delete */}
-                {isDeleting ? (
-                  <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+                  {/* Actions (visible on hover) */}
+                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                    {/* More menu */}
                     <button
-                      onClick={() => { onDeleteThread(thread.id); setConfirmDelete(null) }}
-                      className="text-xs text-red-400 hover:text-red-300 px-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMenuOpenFolderId(isMenuOpen ? null : folder.id);
+                      }}
+                      className="p-0.5 rounded text-gray-500 hover:text-gray-300 transition-colors"
+                      title="Folder options"
                     >
-                      Delete
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle cx="12" cy="5" r="2" />
+                        <circle cx="12" cy="12" r="2" />
+                        <circle cx="12" cy="19" r="2" />
+                      </svg>
                     </button>
+
+                    {/* New thread */}
                     <button
-                      onClick={() => setConfirmDelete(null)}
-                      className="text-xs text-gray-500 hover:text-gray-300 px-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCreateThreadInFolder(folder.id);
+                      }}
+                      className="p-0.5 rounded text-gray-500 hover:text-gray-300 transition-colors"
+                      title={`New thread in ${folder.name}`}
                     >
-                      Cancel
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                        />
+                      </svg>
                     </button>
                   </div>
-                ) : (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setConfirmDelete(thread.id) }}
-                    className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-gray-600 hover:text-red-400 transition-all"
-                    title="Delete thread"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                    </svg>
-                  </button>
+
+                  {/* Dropdown menu */}
+                  {isMenuOpen && (
+                    <FolderMenu
+                      onRemove={() => onRemoveFolder(folder.id)}
+                      onClose={() => setMenuOpenFolderId(null)}
+                    />
+                  )}
+                </div>
+
+                {/* Threads under folder */}
+                {!isCollapsed && (
+                  <div className="space-y-0.5 mt-0.5">
+                    {folderThreads.length === 0 ? (
+                      <p className="text-xs text-gray-600 py-1 pl-7 pr-3">
+                        No threads
+                      </p>
+                    ) : (
+                      folderThreads.map((thread) => (
+                        <ThreadRow
+                          key={thread.id}
+                          thread={thread}
+                          isActive={thread.id === activeThreadId}
+                          isRunning={runningThreadIds.includes(thread.id)}
+                          notification={threadNotifications.get(thread.id)}
+                          confirmDelete={confirmDelete}
+                          onThreadClick={onThreadClick}
+                          onDeleteThread={onDeleteThread}
+                          setConfirmDelete={setConfirmDelete}
+                        />
+                      ))
+                    )}
+                  </div>
                 )}
               </div>
-            )
+            );
           })
         )}
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- Replace flat thread list with folder→threads hierarchy in the sidebar
- Users add project folders via directory picker; new threads are created instantly inside a folder (no per-thread directory picker)
- Folders are collapsible with persisted state, removable via context menu
- Full stack: core types + storage, IPC channels + handlers, preload API, React hook, UI components

## Test plan
- [ ] Add a folder via "+" button in sidebar header → OS directory picker opens, folder appears
- [ ] Create a thread in a folder via pencil icon on hover → thread created instantly with correct cwd
- [ ] Collapse/expand folders → state persists across app restarts
- [ ] Remove folder via "..." menu → folder removed, threads unaffected on disk
- [ ] Verify all 153 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)