### PR TITLE
fix: remove redundant Files label in file explorer header

### DIFF
--- a/packages/desktop/src/renderer/hooks/usePreview.ts
+++ b/packages/desktop/src/renderer/hooks/usePreview.ts
@@ -42,7 +42,7 @@ export function usePreview() {
   );
 
   const openFileExplorer = useCallback((cwd: string) => {
-    setPreview({ isOpen: true, type: "file-explorer", title: "Files", cwd });
+    setPreview({ isOpen: true, type: "file-explorer", title: "", cwd });
   }, []);
 
   const close = useCallback(() => {


### PR DESCRIPTION
## Summary
- The file explorer preview pane showed "FILES Files" — a badge and a duplicate title
- Set the title to empty string so only the badge remains

## Test plan
- [x] Verified visually via Chrome DevTools MCP that the header now shows only the "FILES" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)