### PR TITLE
feat: polish chat UI with DM Sans/Mono fonts, cleaner layout, and thread status pills

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -135,6 +135,7 @@ export default function App(): React.ReactElement {
     slashCommands,
     runningThreadIds,
     threadNotifications,
+    pendingPermissionThreadIds,
     sessionTools,
   } = useChat(activeThreadId, { onThreadUpdated: refreshThreads });
 
@@ -472,6 +473,7 @@ export default function App(): React.ReactElement {
           onSettingsClick={() => setShowSettingsDialog(true)}
           runningThreadIds={runningThreadIds}
           threadNotifications={threadNotifications}
+          pendingPermissionThreadIds={pendingPermissionThreadIds}
         />
       </div>
 

--- a/packages/desktop/src/renderer/hooks/useChat.ts
+++ b/packages/desktop/src/renderer/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import type {
   ChatMessage,
   ToolCall,
@@ -52,6 +52,7 @@ interface UseChatReturn {
   sessionTools: string[] | null;
   runningThreadIds: string[];
   threadNotifications: Map<string, string>;
+  pendingPermissionThreadIds: Set<string>;
 }
 
 let messageIdCounter = 0;
@@ -153,6 +154,16 @@ export function useChat(
     permissionRequests.find(
       (r) => !r.threadId || r.threadId === activeThreadId,
     ) ?? null;
+
+  const pendingPermissionThreadIds = useMemo(
+    () =>
+      new Set(
+        permissionRequests
+          .map((r) => r.threadId)
+          .filter((id): id is string => !!id),
+      ),
+    [permissionRequests],
+  );
 
   const prevThreadIdRef = useRef<string | null>(null);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -652,6 +663,12 @@ export function useChat(
           // Clear running state immediately — result means the turn is complete.
           // The main process also sends THREAD_STREAM_STATE, but the SDK generator
           // may not close promptly, so we clear here as defense-in-depth.
+          if (threadId !== activeThreadIdRef.current) {
+            setThreadNotifications((n) => {
+              if (n.has(threadId)) return n;
+              return new Map(n).set(threadId, "done");
+            });
+          }
           setRunningThreadIds((prev) => prev.filter((id) => id !== threadId));
           break;
         }
@@ -803,6 +820,19 @@ export function useChat(
     // Listen for thread stream state changes from main process
     api.onThreadStreamState(({ threadId, isRunning }) => {
       setRunningThreadIds((prev) => {
+        // When a thread stops running and it's not the active thread,
+        // set a "done" notification so the sidebar shows a Done pill.
+        if (
+          !isRunning &&
+          prev.includes(threadId) &&
+          threadId !== activeThreadIdRef.current
+        ) {
+          setThreadNotifications((n) => {
+            // Don't overwrite a more important notification (permission/question)
+            if (n.has(threadId)) return n;
+            return new Map(n).set(threadId, "done");
+          });
+        }
         if (isRunning)
           return prev.includes(threadId) ? prev : [...prev, threadId];
         return prev.filter((id) => id !== threadId);
@@ -1109,5 +1139,6 @@ export function useChat(
     sessionTools,
     runningThreadIds,
     threadNotifications,
+    pendingPermissionThreadIds,
   };
 }

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -2,6 +2,11 @@
 @source "../../../../packages/ui/src/**/*.tsx";
 @source "../../../../packages/ui/src/**/*.ts";
 
+@theme inline {
+  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'DM Mono', 'SF Mono', SFMono-Regular, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -9,9 +14,14 @@ body {
   background: transparent;
   color: #e0e0e0;
   height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Ensure code/pre elements use mono font */
+pre, code, kbd, samp {
+  font-family: var(--font-mono);
 }
 
 #root {

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet" />
     <title>AgentPanel</title>
   </head>
   <body class="h-full">

--- a/packages/ui/src/__tests__/ChatInfoBar.test.tsx
+++ b/packages/ui/src/__tests__/ChatInfoBar.test.tsx
@@ -7,7 +7,7 @@ describe("ChatInfoBar", () => {
     cleanup();
   });
 
-  it("renders the working directory bar without a stats icon (stats moved to bottom toolbar)", () => {
+  it("renders the info bar with add directory button", () => {
     render(
       <ChatInfoBar
         additionalCwds={[]}
@@ -24,7 +24,7 @@ describe("ChatInfoBar", () => {
     );
 
     expect(screen.queryByLabelText("Session stats")).not.toBeInTheDocument();
-    expect(screen.getByText("Working directory")).toBeInTheDocument();
+    expect(screen.getByTitle("Add working directory")).toBeInTheDocument();
   });
 
   it("does not render stats icon when session stats are empty", () => {

--- a/packages/ui/src/components/ChatInfoBar.tsx
+++ b/packages/ui/src/components/ChatInfoBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { TodoData } from "../types";
+import { basename } from "../utils/path";
 import { ToolsBadge } from "./ToolsBadge";
 import WorktreeToggle from "./WorktreeToggle";
 
@@ -16,7 +17,7 @@ interface ChatInfoBarProps {
   onAddDirectory: () => void;
   onRemoveDirectory: (path: string) => void;
   sessionStats: SessionStats;
-  homeDir: string;
+  homeDir?: string;
   sessionTools?: string[];
   todoData?: TodoData | null;
   onToggleTaskPanel?: () => void;
@@ -25,12 +26,6 @@ interface ChatInfoBarProps {
   hasMessages?: boolean;
   onWorktreeModeChange?: (mode: "local" | "worktree") => void;
   onToggleFileExplorer?: () => void;
-}
-
-function shortenPath(path: string, homeDir: string): string {
-  return homeDir && path.startsWith(homeDir)
-    ? "~" + path.slice(homeDir.length)
-    : path;
 }
 
 export function ChatInfoBar({
@@ -49,28 +44,24 @@ export function ChatInfoBar({
   onToggleFileExplorer,
 }: ChatInfoBarProps): React.ReactElement {
   return (
-    <div className="flex-shrink-0 bg-[#0f0f0f] border-b border-[#1a1a1a] px-4 py-1.5">
-      <div className="flex items-center justify-between text-xs text-gray-500 gap-3 min-h-[28px]">
+    <div className="flex-shrink-0 bg-[#0f0f0f] border-b border-white/[0.06] px-3 py-1">
+      <div className="flex items-center justify-between text-xs gap-2 min-h-[28px]">
+        {/* Left: directory pills */}
         <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
-          <span className="text-gray-600 whitespace-nowrap flex-shrink-0">
-            Working directory
-          </span>
           {primaryCwd && (
             <span
-              className="no-drag flex items-center gap-1 px-2 py-0.5 rounded bg-[#1a1a1a] text-gray-400 whitespace-nowrap flex-shrink-0"
-              title={`Working directory: ${primaryCwd}`}
+              className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.04] text-gray-400 whitespace-nowrap flex-shrink-0"
+              title={primaryCwd}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"
-                className="w-3 h-3 flex-shrink-0"
+                className="w-3 h-3 flex-shrink-0 text-gray-500"
               >
                 <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
               </svg>
-              <span className="truncate max-w-[180px]">
-                {shortenPath(primaryCwd, homeDir)}
-              </span>
+              {basename(primaryCwd)}
             </span>
           )}
           {isGitRepo && onWorktreeModeChange && (
@@ -84,23 +75,21 @@ export function ChatInfoBar({
           {additionalCwds.map((cwd) => (
             <span
               key={cwd}
-              className="no-drag flex items-center gap-1 px-2 py-0.5 rounded bg-[#1a1a1a] text-gray-400 whitespace-nowrap flex-shrink-0"
-              title={`Additional directory: ${cwd}`}
+              className="no-drag group flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.04] text-gray-400 whitespace-nowrap flex-shrink-0"
+              title={cwd}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"
-                className="w-3 h-3 flex-shrink-0"
+                className="w-3 h-3 flex-shrink-0 text-gray-500"
               >
                 <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
               </svg>
-              <span className="truncate max-w-[180px]">
-                {shortenPath(cwd, homeDir)}
-              </span>
+              {basename(cwd)}
               <button
                 onClick={() => onRemoveDirectory(cwd)}
-                className="ml-0.5 text-gray-600 hover:text-gray-300 transition-colors"
+                className="text-gray-600 hover:text-gray-300 transition-colors opacity-0 group-hover:opacity-100"
                 title="Remove directory"
               >
                 <svg
@@ -121,52 +110,8 @@ export function ChatInfoBar({
           ))}
           <button
             onClick={onAddDirectory}
-            className="no-drag flex items-center gap-1 px-2 py-0.5 rounded text-gray-600 hover:text-gray-400 hover:bg-[#1a1a1a] transition-colors whitespace-nowrap flex-shrink-0"
+            className="no-drag p-1 rounded-md text-gray-600 hover:text-gray-400 hover:bg-white/[0.04] transition-colors flex-shrink-0"
             title="Add working directory"
-          >
-            <svg
-              className="w-3 h-3"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-            <span>Add</span>
-          </button>
-
-          {sessionTools && sessionTools.length > 0 && (
-            <ToolsBadge
-              toolCount={sessionTools.length}
-              sessionTools={sessionTools}
-            />
-          )}
-
-          {todoData && todoData.todos.length > 0 && (
-            <button
-              onClick={() => onToggleTaskPanel?.()}
-              title="Toggle task panel"
-              className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-[#1a1a1a] text-gray-400 hover:bg-[#2a2a2a] transition-colors whitespace-nowrap"
-            >
-              <span className="text-gray-500 text-xs">○</span>
-              <span className="text-xs">
-                {todoData.todos.filter((t) => t.status === "completed").length}/
-                {todoData.todos.length} tasks
-              </span>
-            </button>
-          )}
-        </div>
-
-        {primaryCwd && onToggleFileExplorer && (
-          <button
-            onClick={onToggleFileExplorer}
-            className="no-drag p-1 rounded text-gray-600 hover:text-gray-400 hover:bg-[#1a1a1a] transition-colors"
-            title="Toggle file explorer"
           >
             <svg
               className="w-3.5 h-3.5"
@@ -178,11 +123,56 @@ export function ChatInfoBar({
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
+                d="M12 4v16m8-8H4"
               />
             </svg>
           </button>
-        )}
+        </div>
+
+        {/* Right: tools, tasks, file explorer */}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {sessionTools && sessionTools.length > 0 && (
+            <ToolsBadge
+              toolCount={sessionTools.length}
+              sessionTools={sessionTools}
+            />
+          )}
+
+          {todoData && todoData.todos.length > 0 && (
+            <button
+              onClick={() => onToggleTaskPanel?.()}
+              title="Toggle task panel"
+              className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.04] text-gray-400 hover:bg-white/[0.07] transition-colors whitespace-nowrap"
+            >
+              <span className="text-xs">
+                {todoData.todos.filter((t) => t.status === "completed").length}/
+                {todoData.todos.length}
+              </span>
+            </button>
+          )}
+
+          {primaryCwd && onToggleFileExplorer && (
+            <button
+              onClick={onToggleFileExplorer}
+              className="no-drag p-1 rounded-md text-gray-600 hover:text-gray-400 hover:bg-white/[0.04] transition-colors"
+              title="Toggle file explorer"
+            >
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/components/ChatView.tsx
+++ b/packages/ui/src/components/ChatView.tsx
@@ -92,7 +92,7 @@ export function ChatView({
       onScroll={handleScroll}
       className="flex-1 overflow-y-auto px-4 py-2 relative"
     >
-      <div className="space-y-4">
+      <div className="max-w-3xl mx-auto space-y-4">
         {messages.map((msg, idx) => (
           <MessageBubble
             key={msg.id}

--- a/packages/ui/src/components/FileChangeViewer.tsx
+++ b/packages/ui/src/components/FileChangeViewer.tsx
@@ -1,35 +1,37 @@
-import { useState, useEffect } from 'react'
-import { Editor, DiffEditor } from '@monaco-editor/react'
-import type { ToolCall } from '../types'
+import { useState, useEffect } from "react";
+import { Editor, DiffEditor } from "@monaco-editor/react";
+import { useMonacoFontReady } from "../hooks/useMonacoFontReady";
+import type { ToolCall } from "../types";
 import {
   getLanguageFromPath,
+  MONO_FONT_FAMILY,
   isBinaryFile,
   calculateEditorHeight,
   countLines,
   getFileName,
-} from '../utils/monaco-language'
-import '../utils/monaco-theme'
+} from "../utils/monaco-language";
+import "../utils/monaco-theme";
 
 interface Props {
-  toolCall: ToolCall
+  toolCall: ToolCall;
 }
 
-const statusColors: Record<ToolCall['status'], string> = {
-  pending: 'text-yellow-400',
-  running: 'text-blue-400',
-  completed: 'text-green-400',
-  denied: 'text-red-400',
-}
+const statusColors: Record<ToolCall["status"], string> = {
+  pending: "text-yellow-400",
+  running: "text-blue-400",
+  completed: "text-green-400",
+  denied: "text-red-400",
+};
 
-const statusLabels: Record<ToolCall['status'], string> = {
-  pending: 'Pending',
-  running: 'Running...',
-  completed: 'Done',
-  denied: 'Denied',
-}
+const statusLabels: Record<ToolCall["status"], string> = {
+  pending: "Pending",
+  running: "Running...",
+  completed: "Done",
+  denied: "Denied",
+};
 
-const MAX_LINES_INLINE = 500
-const MAX_VISIBLE_LINES = 30
+const MAX_LINES_INLINE = 500;
+const MAX_VISIBLE_LINES = 30;
 
 function extractFilePath(input: Record<string, unknown>): string {
   return (
@@ -37,76 +39,83 @@ function extractFilePath(input: Record<string, unknown>): string {
     (input.filePath as string | undefined) ??
     (input.path as string | undefined) ??
     (input.file as string | undefined) ??
-    'Unknown file'
-  )
+    "Unknown file"
+  );
 }
 
-function calculateChangeStats(oldContent: string, newContent: string): { added: number; removed: number } {
-  const oldLines = oldContent.split('\n')
-  const newLines = newContent.split('\n')
+function calculateChangeStats(
+  oldContent: string,
+  newContent: string,
+): { added: number; removed: number } {
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
 
   // Simple line-based diff (not perfect but good enough for stats)
-  const oldSet = new Set(oldLines)
-  const newSet = new Set(newLines)
+  const oldSet = new Set(oldLines);
+  const newSet = new Set(newLines);
 
-  let added = 0
-  let removed = 0
+  let added = 0;
+  let removed = 0;
 
   for (const line of newLines) {
-    if (!oldSet.has(line)) added++
+    if (!oldSet.has(line)) added++;
   }
 
   for (const line of oldLines) {
-    if (!newSet.has(line)) removed++
+    if (!newSet.has(line)) removed++;
   }
 
-  return { added, removed }
+  return { added, removed };
 }
 
 export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [shouldRenderMonaco, setShouldRenderMonaco] = useState(false)
+  useMonacoFontReady();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [shouldRenderMonaco, setShouldRenderMonaco] = useState(false);
 
-  const filePath = extractFilePath(toolCall.input)
-  const fileName = getFileName(filePath)
-  const isBinary = isBinaryFile(filePath)
-  const language = getLanguageFromPath(filePath)
+  const filePath = extractFilePath(toolCall.input);
+  const fileName = getFileName(filePath);
+  const isBinary = isBinaryFile(filePath);
+  const language = getLanguageFromPath(filePath);
 
   // Debounce Monaco rendering to prevent janky animation
   useEffect(() => {
     if (isExpanded) {
-      const timer = setTimeout(() => setShouldRenderMonaco(true), 150)
-      return () => clearTimeout(timer)
+      const timer = setTimeout(() => setShouldRenderMonaco(true), 150);
+      return () => clearTimeout(timer);
     } else {
-      setShouldRenderMonaco(false)
+      setShouldRenderMonaco(false);
     }
-  }, [isExpanded])
+  }, [isExpanded]);
 
   // Extract content based on tool type
-  let oldContent = ''
-  let newContent = ''
-  let displayContent = ''
-  let isTooLarge = false
+  let oldContent = "";
+  let newContent = "";
+  let displayContent = "";
+  let isTooLarge = false;
 
-  if (toolCall.toolName === 'Edit') {
-    oldContent = (toolCall.input.old_string as string | undefined) ?? ''
-    newContent = (toolCall.input.new_string as string | undefined) ?? ''
-    isTooLarge = countLines(newContent) > MAX_LINES_INLINE
-  } else if (toolCall.toolName === 'Write') {
-    displayContent = (toolCall.input.content as string | undefined) ?? ''
-    isTooLarge = countLines(displayContent) > MAX_LINES_INLINE
-  } else if (toolCall.toolName === 'Read') {
-    displayContent = toolCall.output ?? ''
-    isTooLarge = countLines(displayContent) > MAX_LINES_INLINE
+  if (toolCall.toolName === "Edit") {
+    oldContent = (toolCall.input.old_string as string | undefined) ?? "";
+    newContent = (toolCall.input.new_string as string | undefined) ?? "";
+    isTooLarge = countLines(newContent) > MAX_LINES_INLINE;
+  } else if (toolCall.toolName === "Write") {
+    displayContent = (toolCall.input.content as string | undefined) ?? "";
+    isTooLarge = countLines(displayContent) > MAX_LINES_INLINE;
+  } else if (toolCall.toolName === "Read") {
+    displayContent = toolCall.output ?? "";
+    isTooLarge = countLines(displayContent) > MAX_LINES_INLINE;
   }
 
-  const changeStats = toolCall.toolName === 'Edit' ? calculateChangeStats(oldContent, newContent) : null
+  const changeStats =
+    toolCall.toolName === "Edit"
+      ? calculateChangeStats(oldContent, newContent)
+      : null;
   const height = calculateEditorHeight(
-    toolCall.toolName === 'Edit' ? newContent : displayContent,
-    MAX_VISIBLE_LINES
-  )
+    toolCall.toolName === "Edit" ? newContent : displayContent,
+    MAX_VISIBLE_LINES,
+  );
 
-  const toggleExpand = () => setIsExpanded(!isExpanded)
+  const toggleExpand = () => setIsExpanded(!isExpanded);
 
   // Binary file indicator
   if (isBinary) {
@@ -114,7 +123,9 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
       <div className="rounded-lg bg-[#111] border border-[#333] p-3 text-xs">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="font-mono font-semibold text-gray-300">{toolCall.toolName}</span>
+            <span className="font-mono font-semibold text-gray-300">
+              {toolCall.toolName}
+            </span>
             <span className="text-gray-500">•</span>
             <span className="font-mono text-gray-400">{fileName}</span>
           </div>
@@ -123,23 +134,24 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
           </span>
         </div>
         <div className="mt-2 text-gray-500 text-xs">
-          📦 Binary file ({fileName.split('.').pop()?.toUpperCase()})
+          📦 Binary file ({fileName.split(".").pop()?.toUpperCase()})
         </div>
       </div>
-    )
+    );
   }
 
   // Empty file indicator
-  const isEmpty = toolCall.toolName === 'Edit'
-    ? !oldContent && !newContent
-    : !displayContent
+  const isEmpty =
+    toolCall.toolName === "Edit" ? !oldContent && !newContent : !displayContent;
 
   if (isEmpty) {
     return (
       <div className="rounded-lg bg-[#111] border border-[#333] p-3 text-xs">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="font-mono font-semibold text-gray-300">{toolCall.toolName}</span>
+            <span className="font-mono font-semibold text-gray-300">
+              {toolCall.toolName}
+            </span>
             <span className="text-gray-500">•</span>
             <span className="font-mono text-gray-400">{fileName}</span>
           </div>
@@ -147,11 +159,9 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
             {statusLabels[toolCall.status]}
           </span>
         </div>
-        <div className="mt-2 text-gray-500 text-xs">
-          📄 Empty file
-        </div>
+        <div className="mt-2 text-gray-500 text-xs">📄 Empty file</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -161,24 +171,29 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
         onClick={toggleExpand}
         className="w-full p-3 flex items-center justify-between hover:bg-[#1a1a1a] transition-colors text-left"
         aria-expanded={isExpanded}
-        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${toolCall.toolName} for ${fileName}`}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} ${toolCall.toolName} for ${fileName}`}
       >
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          <span className="text-gray-400 flex-shrink-0">{isExpanded ? '▾' : '▸'}</span>
-          <span className="font-mono font-semibold text-gray-300 flex-shrink-0">{toolCall.toolName}</span>
+          <span className="text-gray-400 flex-shrink-0">
+            {isExpanded ? "▾" : "▸"}
+          </span>
+          <span className="font-mono font-semibold text-gray-300 flex-shrink-0">
+            {toolCall.toolName}
+          </span>
           <span className="text-gray-500 flex-shrink-0">•</span>
           <span className="font-mono text-gray-400 truncate" title={filePath}>
             {fileName}
           </span>
           {changeStats && (
             <span className="text-gray-500 flex-shrink-0 ml-1">
-              <span className="text-green-400">+{changeStats.added}</span>
-              {' '}
+              <span className="text-green-400">+{changeStats.added}</span>{" "}
               <span className="text-red-400">-{changeStats.removed}</span>
             </span>
           )}
         </div>
-        <span className={`text-xs ml-2 flex-shrink-0 ${statusColors[toolCall.status]}`}>
+        <span
+          className={`text-xs ml-2 flex-shrink-0 ${statusColors[toolCall.status]}`}
+        >
           {statusLabels[toolCall.status]}
         </span>
       </button>
@@ -190,16 +205,21 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
             // Too large - show message
             <div className="p-4 text-center">
               <div className="text-gray-400 mb-2">
-                📊 File too large for inline preview ({countLines(toolCall.toolName === 'Edit' ? newContent : displayContent)} lines)
+                📊 File too large for inline preview (
+                {countLines(
+                  toolCall.toolName === "Edit" ? newContent : displayContent,
+                )}{" "}
+                lines)
               </div>
               <div className="text-gray-500 text-xs">
-                Files larger than {MAX_LINES_INLINE} lines are not displayed inline.
+                Files larger than {MAX_LINES_INLINE} lines are not displayed
+                inline.
               </div>
             </div>
           ) : shouldRenderMonaco ? (
             // Render Monaco editor or diff
             <div className="relative">
-              {toolCall.toolName === 'Edit' ? (
+              {toolCall.toolName === "Edit" ? (
                 // Diff view for Edit tool
                 <DiffEditor
                   height={height}
@@ -213,12 +233,13 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
                     minimap: { enabled: false },
                     scrollBeyondLastLine: false,
                     fontSize: 12,
-                    lineNumbers: 'on',
-                    renderLineHighlight: 'none',
-                    wordWrap: 'on',
+                    fontFamily: MONO_FONT_FAMILY,
+                    lineNumbers: "on",
+                    renderLineHighlight: "none",
+                    wordWrap: "on",
                     scrollbar: {
-                      vertical: 'auto',
-                      horizontal: 'auto',
+                      vertical: "auto",
+                      horizontal: "auto",
                       useShadows: false,
                     },
                     overviewRulerLanes: 0,
@@ -229,8 +250,8 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
                     glyphMargin: false,
                     lineDecorationsWidth: 0,
                     lineNumbersMinChars: 3,
-                    renderWhitespace: 'none',
-                    diffWordWrap: 'on',
+                    renderWhitespace: "none",
+                    diffWordWrap: "on",
                   }}
                 />
               ) : (
@@ -245,12 +266,13 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
                     minimap: { enabled: false },
                     scrollBeyondLastLine: false,
                     fontSize: 12,
-                    lineNumbers: 'on',
-                    renderLineHighlight: 'none',
-                    wordWrap: 'on',
+                    fontFamily: MONO_FONT_FAMILY,
+                    lineNumbers: "on",
+                    renderLineHighlight: "none",
+                    wordWrap: "on",
                     scrollbar: {
-                      vertical: 'auto',
-                      horizontal: 'auto',
+                      vertical: "auto",
+                      horizontal: "auto",
                       useShadows: false,
                     },
                     contextmenu: false,
@@ -259,7 +281,7 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
                     glyphMargin: false,
                     lineDecorationsWidth: 0,
                     lineNumbersMinChars: 3,
-                    renderWhitespace: 'none',
+                    renderWhitespace: "none",
                   }}
                 />
               )}
@@ -273,5 +295,5 @@ export function FileChangeViewer({ toolCall }: Props): React.ReactElement {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/packages/ui/src/components/FileExplorer.tsx
+++ b/packages/ui/src/components/FileExplorer.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { Editor } from "@monaco-editor/react";
-import { getLanguageFromPath } from "../utils/monaco-language";
+import { useMonacoFontReady } from "../hooks/useMonacoFontReady";
+import {
+  getLanguageFromPath,
+  MONO_FONT_FAMILY,
+} from "../utils/monaco-language";
 import "../utils/monaco-theme";
 import type { DirEntry } from "../bridges/types";
 
@@ -91,6 +95,7 @@ export function FileExplorer({
   listDirectory,
   readFile,
 }: Props): React.ReactElement {
+  useMonacoFontReady();
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [openFile, setOpenFile] = useState<{
     path: string;
@@ -244,6 +249,7 @@ export function FileExplorer({
                 minimap: { enabled: false },
                 scrollBeyondLastLine: false,
                 fontSize: 12,
+                fontFamily: MONO_FONT_FAMILY,
                 lineNumbers: "on",
                 renderLineHighlight: "none",
                 folding: true,

--- a/packages/ui/src/components/MessageBubble.tsx
+++ b/packages/ui/src/components/MessageBubble.tsx
@@ -70,16 +70,16 @@ function ThinkingBlock({
   };
 
   return (
-    <div className="mb-2 rounded-lg border border-[#2a2a2a] bg-[#111] text-xs text-gray-500">
+    <div className="mb-1">
       <button
         onClick={handleToggle}
-        className="flex w-full items-center gap-1.5 px-3 py-2 text-left hover:text-gray-400"
+        className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-400 transition-colors"
       >
-        <span className="text-gray-600">{expanded ? "▾" : "▸"}</span>
-        {expanded ? "Hide reasoning" : "View reasoning"}
+        <span className="text-[10px]">{expanded ? "▾" : "▸"}</span>
+        {expanded ? "Hide reasoning" : "Reasoning"}
       </button>
       {expanded && (
-        <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words border-t border-[#2a2a2a] px-3 py-2 font-sans leading-relaxed text-gray-500">
+        <pre className="mt-1 max-h-64 overflow-y-auto whitespace-pre-wrap break-words pl-3 border-l-2 border-white/[0.06] font-sans text-xs leading-relaxed text-gray-500">
           {content}
         </pre>
       )}
@@ -148,7 +148,9 @@ function buildMarkdownComponents(onLinkClick?: (url: string) => void) {
     },
     h3({ children }: { children?: React.ReactNode }) {
       return (
-        <h3 className="text-base font-bold mb-2 mt-2 first:mt-0">{children}</h3>
+        <h3 className="text-base font-bold mb-2 mt-2 first:mt-0">
+          {children}
+        </h3>
       );
     },
     blockquote({ children }: { children?: React.ReactNode }) {
@@ -307,158 +309,186 @@ export function MessageBubble({
     );
   }
 
+  const hasTextContent = !!(
+    cleanContent ||
+    message.thinking ||
+    message.questionData ||
+    message.planReviewData ||
+    message.todoData ||
+    message.worktreeProgress
+  );
+  const regularToolCalls = !message.taskInfo
+    ? (message.toolCalls ?? []).filter((tc) => tc.toolName !== "Task")
+    : [];
+  const hasToolCalls = regularToolCalls.length > 0 || !!message.taskInfo;
+
   return (
-    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-      <div
-        className={`max-w-[85%] rounded-2xl px-4 py-3 break-words ${
-          isUser
-            ? "bg-blue-600 text-white"
-            : "bg-[#1a1a1a] text-gray-200 border border-[#2a2a2a]"
-        }`}
-      >
-        {/* Thinking block */}
-        {message.thinking && (
-          <ThinkingBlock
-            content={message.thinking}
-            isStreaming={isStreaming && !message.content}
-          />
-        )}
-
-        {/* Document attachment chips (user messages only) */}
-        {isUser && attachments.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-2">
-            {attachments.map((att, i) => (
-              <a
-                key={i}
-                href={att.url}
-                onClick={
-                  att.url
-                    ? (e) => {
-                        e.preventDefault();
-                        onLinkClick?.(att.url!);
-                      }
-                    : undefined
-                }
-                className="flex items-center gap-1.5 bg-blue-500/20 border border-blue-400/30 rounded-lg px-2 py-1 text-xs text-blue-100 hover:bg-blue-500/30 transition-colors no-underline cursor-pointer"
-                title={att.url}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="w-3 h-3 flex-shrink-0"
-                >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span className="truncate max-w-[200px]">{att.title}</span>
-              </a>
-            ))}
-          </div>
-        )}
-
-        {/* Image attachments (user messages only) */}
-        {isUser && message.images && message.images.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-2">
-            {message.images.map((img) => (
-              <img
-                key={img.id}
-                src={img.dataUrl}
-                alt={img.name}
-                title={img.name}
-                className="max-w-[200px] max-h-[200px] rounded-lg object-cover border border-blue-500/30"
+    <div className="space-y-2">
+      {/* Message content — user gets a bubble, assistant flows full-width */}
+      {(isUser || hasTextContent) && (
+        <div className={isUser ? "flex justify-end" : ""}>
+          <div
+            className={
+              isUser
+                ? "max-w-[85%] rounded-2xl px-4 py-3 break-words bg-blue-600 text-white"
+                : "w-full break-words text-gray-200 py-1"
+            }
+          >
+            {/* Thinking block */}
+            {message.thinking && (
+              <ThinkingBlock
+                content={message.thinking}
+                isStreaming={isStreaming && !message.content}
               />
-            ))}
-          </div>
-        )}
+            )}
 
-        {/* Message text */}
-        {cleanContent && (
-          <div className="text-sm leading-relaxed prose prose-invert prose-sm max-w-none">
-            <MarkdownContent content={cleanContent} onLinkClick={onLinkClick} />
-          </div>
-        )}
-
-        {/* Inline question from AskUserQuestion SDK tool */}
-        {message.questionData && (
-          <QuestionSequence
-            questionData={message.questionData}
-            onComplete={(requestId, answers) => {
-              if (onQuestionAnswer) {
-                onQuestionAnswer(requestId, answers);
-              }
-            }}
-            disabled={!onQuestionAnswer || !!message.questionAnswered}
-            initiallyAnswered={message.questionAnswered}
-          />
-        )}
-
-        {/* Inline plan review from ExitPlanMode SDK tool */}
-        {message.planReviewData && onPlanReviewDecision && (
-          <div className="mt-3">
-            <PlanReviewBlock
-              data={message.planReviewData}
-              onDecision={onPlanReviewDecision}
-              onViewPlan={onViewPlan}
-            />
-          </div>
-        )}
-
-        {/* Inline TODO list */}
-        {message.todoData && <TodoList todoData={message.todoData} />}
-
-        {/* Worktree progress */}
-        {message.worktreeProgress && (
-          <WorktreeProgress progressData={message.worktreeProgress} />
-        )}
-
-        {/* Task card (for Task tool calls with nested child tools) */}
-        {message.taskInfo && (
-          <div className={`${message.content ? "mt-3" : ""}`}>
-            <TaskCard
-              taskInfo={message.taskInfo}
-              childToolCalls={
-                message.toolCalls?.filter((tc) =>
-                  message.taskInfo!.childToolCalls.includes(tc.toolCallId),
-                ) ?? []
-              }
-              onToggleToolCalls={(expanded) => {
-                onUpdateTaskExpanded?.(message.id, expanded);
-              }}
-            />
-          </div>
-        )}
-
-        {/* Regular tool calls (not part of a task) */}
-        {message.toolCalls &&
-          message.toolCalls.length > 0 &&
-          !message.taskInfo && (
-            <div className={`space-y-2 ${message.content ? "mt-3" : ""}`}>
-              {message.toolCalls
-                .filter((tc) => tc.toolName !== "Task")
-                .map((tc) => (
-                  <ToolCallCard key={tc.toolCallId} toolCall={tc} />
+            {/* Document attachment chips (user messages only) */}
+            {isUser && attachments.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {attachments.map((att, i) => (
+                  <a
+                    key={i}
+                    href={att.url}
+                    onClick={
+                      att.url
+                        ? (e) => {
+                            e.preventDefault();
+                            onLinkClick?.(att.url!);
+                          }
+                        : undefined
+                    }
+                    className="flex items-center gap-1.5 bg-blue-500/20 border border-blue-400/30 rounded-lg px-2 py-1 text-xs text-blue-100 hover:bg-blue-500/30 transition-colors no-underline cursor-pointer"
+                    title={att.url}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="w-3 h-3 flex-shrink-0"
+                    >
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                      <polyline points="14 2 14 8 20 8" />
+                    </svg>
+                    <span className="truncate max-w-[200px]">{att.title}</span>
+                  </a>
                 ))}
-            </div>
-          )}
+              </div>
+            )}
 
-        {/* Cost info */}
-        {message.cost !== undefined && (
-          <div className="text-xs text-gray-500 mt-2 pt-2 border-t border-gray-700">
-            Cost: ${message.cost.toFixed(4)}
-            {message.usage && (
-              <span className="ml-2">
-                ({message.usage.inputTokens + message.usage.outputTokens}{" "}
-                tokens)
-              </span>
+            {/* Image attachments (user messages only) */}
+            {isUser && message.images && message.images.length > 0 && (
+              <div className="flex flex-wrap gap-2 mb-2">
+                {message.images.map((img) => (
+                  <img
+                    key={img.id}
+                    src={img.dataUrl}
+                    alt={img.name}
+                    title={img.name}
+                    className="max-w-[200px] max-h-[200px] rounded-lg object-cover border border-blue-500/30"
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Message text */}
+            {cleanContent && (
+              <div className="text-sm leading-relaxed prose prose-invert prose-sm max-w-none">
+                <MarkdownContent
+                  content={cleanContent}
+                  onLinkClick={onLinkClick}
+                />
+              </div>
+            )}
+
+            {/* Inline question from AskUserQuestion SDK tool */}
+            {message.questionData && (
+              <QuestionSequence
+                questionData={message.questionData}
+                onComplete={(requestId, answers) => {
+                  if (onQuestionAnswer) {
+                    onQuestionAnswer(requestId, answers);
+                  }
+                }}
+                disabled={!onQuestionAnswer || !!message.questionAnswered}
+                initiallyAnswered={message.questionAnswered}
+              />
+            )}
+
+            {/* Inline plan review from ExitPlanMode SDK tool */}
+            {message.planReviewData && onPlanReviewDecision && (
+              <div className="mt-3">
+                <PlanReviewBlock
+                  data={message.planReviewData}
+                  onDecision={onPlanReviewDecision}
+                  onViewPlan={onViewPlan}
+                />
+              </div>
+            )}
+
+            {/* Inline TODO list */}
+            {message.todoData && <TodoList todoData={message.todoData} />}
+
+            {/* Worktree progress */}
+            {message.worktreeProgress && (
+              <WorktreeProgress progressData={message.worktreeProgress} />
+            )}
+
+            {/* Cost info (shown in bubble when there are no tool calls) */}
+            {!hasToolCalls && message.cost !== undefined && (
+              <div className="text-xs text-gray-500 mt-2 pt-2 border-t border-gray-700">
+                Cost: ${message.cost.toFixed(4)}
+                {message.usage && (
+                  <span className="ml-2">
+                    ({message.usage.inputTokens + message.usage.outputTokens}{" "}
+                    tokens)
+                  </span>
+                )}
+              </div>
             )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
+
+      {/* Tool calls — full-width block outside the bubble */}
+      {message.taskInfo && (
+        <div className="w-full">
+          <TaskCard
+            taskInfo={message.taskInfo}
+            childToolCalls={
+              message.toolCalls?.filter((tc) =>
+                message.taskInfo!.childToolCalls.includes(tc.toolCallId),
+              ) ?? []
+            }
+            onToggleToolCalls={(expanded) => {
+              onUpdateTaskExpanded?.(message.id, expanded);
+            }}
+          />
+        </div>
+      )}
+
+      {regularToolCalls.length > 0 && (
+        <div className="w-full space-y-2">
+          {regularToolCalls.map((tc) => (
+            <ToolCallCard key={tc.toolCallId} toolCall={tc} />
+          ))}
+        </div>
+      )}
+
+      {/* Cost info (shown below tool calls when they exist) */}
+      {hasToolCalls && message.cost !== undefined && (
+        <div className="text-xs text-gray-500 px-1">
+          Cost: ${message.cost.toFixed(4)}
+          {message.usage && (
+            <span className="ml-2">
+              ({message.usage.inputTokens + message.usage.outputTokens} tokens)
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ interface Props {
   onSettingsClick: () => void;
   runningThreadIds: string[];
   threadNotifications: Map<string, string>;
+  pendingPermissionThreadIds?: Set<string>;
 }
 
 export function Sidebar({
@@ -31,6 +32,7 @@ export function Sidebar({
   onSettingsClick,
   runningThreadIds,
   threadNotifications,
+  pendingPermissionThreadIds,
 }: Props): React.ReactElement {
   return (
     <div className="flex-shrink-0 flex flex-col bg-[#0a0a0a] overflow-hidden w-[232px] min-w-[232px] h-full">
@@ -77,6 +79,7 @@ export function Sidebar({
             onDeleteThread={onDeleteThread}
             runningThreadIds={runningThreadIds}
             threadNotifications={threadNotifications}
+            pendingPermissionThreadIds={pendingPermissionThreadIds}
           />
         </div>
 

--- a/packages/ui/src/components/ThreadList.tsx
+++ b/packages/ui/src/components/ThreadList.tsx
@@ -1,5 +1,47 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import type { Thread, Folder } from "@agentpanel/core";
+import { basename } from "../utils/path";
+
+interface StatusPill {
+  label: string;
+  colorClass: string;
+  dotClass: string;
+  pulse: boolean;
+}
+
+function getThreadStatus(
+  threadId: string,
+  isActive: boolean,
+  runningThreadIds: string[],
+  pendingPermissionThreadIds?: Set<string>,
+  threadNotifications?: Map<string, string>,
+): StatusPill | null {
+  if (pendingPermissionThreadIds?.has(threadId)) {
+    return {
+      label: "Awaiting",
+      colorClass: "text-amber-400",
+      dotClass: "bg-amber-400",
+      pulse: false,
+    };
+  }
+  if (runningThreadIds.includes(threadId)) {
+    return {
+      label: "Working",
+      colorClass: "text-violet-400",
+      dotClass: "bg-violet-400",
+      pulse: true,
+    };
+  }
+  if (!isActive && threadNotifications?.has(threadId)) {
+    return {
+      label: "Done",
+      colorClass: "text-emerald-400",
+      dotClass: "bg-emerald-400",
+      pulse: false,
+    };
+  }
+  return null;
+}
 
 interface Props {
   threads: Thread[];
@@ -13,6 +55,7 @@ interface Props {
   onDeleteThread: (threadId: string) => void;
   runningThreadIds: string[];
   threadNotifications: Map<string, string>;
+  pendingPermissionThreadIds?: Set<string>;
 }
 
 function FolderMenu({
@@ -54,8 +97,7 @@ function FolderMenu({
 function ThreadRow({
   thread,
   isActive,
-  isRunning,
-  notification,
+  status,
   confirmDelete,
   onThreadClick,
   onDeleteThread,
@@ -63,8 +105,7 @@ function ThreadRow({
 }: {
   thread: Thread;
   isActive: boolean;
-  isRunning: boolean;
-  notification: string | undefined;
+  status: StatusPill | null;
   confirmDelete: string | null;
   onThreadClick: (id: string) => void;
   onDeleteThread: (id: string) => void;
@@ -81,13 +122,17 @@ function ThreadRow({
       }`}
       onClick={() => onThreadClick(thread.id)}
     >
-      {isRunning && (
-        <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
+      {status && (
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <div
+            className={`w-1.5 h-1.5 rounded-full ${status.dotClass} ${status.pulse ? "animate-pulse" : ""}`}
+          />
+          <span className={`text-[10px] font-medium ${status.colorClass}`}>
+            {status.label}
+          </span>
+        </div>
       )}
       <span className="flex-1 truncate">{thread.title}</span>
-      {notification && !isActive && (
-        <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
-      )}
       {isDeleting ? (
         <div
           className="flex items-center gap-1"
@@ -149,6 +194,7 @@ export function ThreadList({
   onDeleteThread,
   runningThreadIds,
   threadNotifications,
+  pendingPermissionThreadIds,
 }: Props): React.ReactElement {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [menuOpenFolderId, setMenuOpenFolderId] = useState<string | null>(null);
@@ -217,6 +263,7 @@ export function ThreadList({
                 {/* Folder row */}
                 <div
                   className="group no-drag flex items-center gap-1.5 px-2 py-1.5 rounded-lg cursor-pointer transition-colors text-sm text-gray-300 hover:bg-[#1a1a1a] relative"
+                  title={folder.name}
                   onClick={() =>
                     onToggleFolderCollapsed(folder.id, !isCollapsed)
                   }
@@ -253,7 +300,7 @@ export function ThreadList({
 
                   {/* Folder name */}
                   <span className="flex-1 truncate font-medium">
-                    {folder.name}
+                    {basename(folder.name)}
                   </span>
 
                   {/* Actions (visible on hover) */}
@@ -320,19 +367,28 @@ export function ThreadList({
                         No threads
                       </p>
                     ) : (
-                      folderThreads.map((thread) => (
-                        <ThreadRow
-                          key={thread.id}
-                          thread={thread}
-                          isActive={thread.id === activeThreadId}
-                          isRunning={runningThreadIds.includes(thread.id)}
-                          notification={threadNotifications.get(thread.id)}
-                          confirmDelete={confirmDelete}
-                          onThreadClick={onThreadClick}
-                          onDeleteThread={onDeleteThread}
-                          setConfirmDelete={setConfirmDelete}
-                        />
-                      ))
+                      folderThreads.map((thread) => {
+                        const isActive = thread.id === activeThreadId;
+                        const status = getThreadStatus(
+                          thread.id,
+                          isActive,
+                          runningThreadIds,
+                          pendingPermissionThreadIds,
+                          threadNotifications,
+                        );
+                        return (
+                          <ThreadRow
+                            key={thread.id}
+                            thread={thread}
+                            isActive={isActive}
+                            status={status}
+                            confirmDelete={confirmDelete}
+                            onThreadClick={onThreadClick}
+                            onDeleteThread={onDeleteThread}
+                            setConfirmDelete={setConfirmDelete}
+                          />
+                        );
+                      })
                     )}
                   </div>
                 )}

--- a/packages/ui/src/components/preview/ArtifactEditorPreview.tsx
+++ b/packages/ui/src/components/preview/ArtifactEditorPreview.tsx
@@ -1,73 +1,88 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
-import Editor, { type OnMount } from '@monaco-editor/react'
-import { MarkdownPreview } from './MarkdownPreview'
-import '../../utils/monaco-theme'
-import { getLanguageFromPath } from '../../utils/monaco-language'
+import { useState, useRef, useCallback, useEffect } from "react";
+import Editor, { type OnMount } from "@monaco-editor/react";
+import { useMonacoFontReady } from "../../hooks/useMonacoFontReady";
+import { MarkdownPreview } from "./MarkdownPreview";
+import "../../utils/monaco-theme";
+import {
+  getLanguageFromPath,
+  MONO_FONT_FAMILY,
+} from "../../utils/monaco-language";
 
 interface Props {
-  content: string
-  filePath: string
-  onSave?: (content: string) => Promise<void>
+  content: string;
+  filePath: string;
+  onSave?: (content: string) => Promise<void>;
 }
 
 export function ArtifactEditorPreview({ content, filePath, onSave }: Props) {
-  const isMarkdown = filePath.endsWith('.md')
-  const [mode, setMode] = useState<'preview' | 'raw'>(isMarkdown ? 'preview' : 'raw')
-  const [currentContent, setCurrentContent] = useState(content)
-  const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved' | 'idle'>('idle')
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const language = getLanguageFromPath(filePath)
+  useMonacoFontReady();
+  const isMarkdown = filePath.endsWith(".md");
+  const [mode, setMode] = useState<"preview" | "raw">(
+    isMarkdown ? "preview" : "raw",
+  );
+  const [currentContent, setCurrentContent] = useState(content);
+  const [saveStatus, setSaveStatus] = useState<
+    "saved" | "saving" | "unsaved" | "idle"
+  >("idle");
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const language = getLanguageFromPath(filePath);
 
   useEffect(() => {
-    setCurrentContent(content)
-    setSaveStatus('idle')
-    setMode(filePath.endsWith('.md') ? 'preview' : 'raw')
-  }, [content, filePath])
+    setCurrentContent(content);
+    setSaveStatus("idle");
+    setMode(filePath.endsWith(".md") ? "preview" : "raw");
+  }, [content, filePath]);
 
-  const saveToFile = useCallback(async (newContent: string) => {
-    if (!onSave) return
-    setSaveStatus('saving')
-    try {
-      await onSave(newContent)
-      setSaveStatus('saved')
-      setTimeout(() => setSaveStatus('idle'), 2000)
-    } catch {
-      setSaveStatus('unsaved')
-    }
-  }, [onSave])
+  const saveToFile = useCallback(
+    async (newContent: string) => {
+      if (!onSave) return;
+      setSaveStatus("saving");
+      try {
+        await onSave(newContent);
+        setSaveStatus("saved");
+        setTimeout(() => setSaveStatus("idle"), 2000);
+      } catch {
+        setSaveStatus("unsaved");
+      }
+    },
+    [onSave],
+  );
 
-  const handleEditorChange = useCallback((value: string | undefined) => {
-    if (value === undefined) return
-    setCurrentContent(value)
-    setSaveStatus('unsaved')
+  const handleEditorChange = useCallback(
+    (value: string | undefined) => {
+      if (value === undefined) return;
+      setCurrentContent(value);
+      setSaveStatus("unsaved");
 
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(() => saveToFile(value), 1000)
-  }, [saveToFile])
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => saveToFile(value), 1000);
+    },
+    [saveToFile],
+  );
 
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    }
-  }, [])
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
 
   const handleEditorMount: OnMount = (editor) => {
     editor.updateOptions({
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
-      wordWrap: 'on',
-      lineNumbers: 'on',
+      wordWrap: "on",
+      lineNumbers: "on",
       fontSize: 13,
-      fontFamily: "'Geist Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+      fontFamily: MONO_FONT_FAMILY,
       fontLigatures: true,
       padding: { top: 12 },
-      renderLineHighlight: 'line',
-      cursorBlinking: 'smooth',
-      cursorSmoothCaretAnimation: 'on',
+      renderLineHighlight: "line",
+      cursorBlinking: "smooth",
+      cursorSmoothCaretAnimation: "on",
       smoothScrolling: true,
       bracketPairColorization: { enabled: true },
-    })
-  }
+    });
+  };
 
   return (
     <div className="flex flex-col h-full">
@@ -75,17 +90,21 @@ export function ArtifactEditorPreview({ content, filePath, onSave }: Props) {
         {isMarkdown && (
           <div className="flex rounded-md overflow-hidden border border-[#333]">
             <button
-              onClick={() => setMode('preview')}
+              onClick={() => setMode("preview")}
               className={`px-2.5 py-1 text-xs transition-colors ${
-                mode === 'preview' ? 'bg-[#2a2a2a] text-gray-200' : 'text-gray-500 hover:text-gray-300'
+                mode === "preview"
+                  ? "bg-[#2a2a2a] text-gray-200"
+                  : "text-gray-500 hover:text-gray-300"
               }`}
             >
               Preview
             </button>
             <button
-              onClick={() => setMode('raw')}
+              onClick={() => setMode("raw")}
               className={`px-2.5 py-1 text-xs transition-colors ${
-                mode === 'raw' ? 'bg-[#2a2a2a] text-gray-200' : 'text-gray-500 hover:text-gray-300'
+                mode === "raw"
+                  ? "bg-[#2a2a2a] text-gray-200"
+                  : "text-gray-500 hover:text-gray-300"
               }`}
             >
               Raw
@@ -93,12 +112,18 @@ export function ArtifactEditorPreview({ content, filePath, onSave }: Props) {
           </div>
         )}
         <div className="flex-1" />
-        {saveStatus === 'saving' && <span className="text-xs text-gray-500">Saving...</span>}
-        {saveStatus === 'saved' && <span className="text-xs text-green-500">Saved</span>}
-        {saveStatus === 'unsaved' && <span className="text-xs text-yellow-500">Unsaved</span>}
+        {saveStatus === "saving" && (
+          <span className="text-xs text-gray-500">Saving...</span>
+        )}
+        {saveStatus === "saved" && (
+          <span className="text-xs text-green-500">Saved</span>
+        )}
+        {saveStatus === "unsaved" && (
+          <span className="text-xs text-yellow-500">Unsaved</span>
+        )}
       </div>
 
-      {mode === 'preview' && isMarkdown ? (
+      {mode === "preview" && isMarkdown ? (
         <MarkdownPreview content={currentContent} />
       ) : (
         <Editor
@@ -111,20 +136,20 @@ export function ArtifactEditorPreview({ content, filePath, onSave }: Props) {
           options={{
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
-            wordWrap: 'on',
-            lineNumbers: 'on',
+            wordWrap: "on",
+            lineNumbers: "on",
             fontSize: 13,
-            fontFamily: "'Geist Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+            fontFamily: MONO_FONT_FAMILY,
             fontLigatures: true,
             padding: { top: 12 },
-            renderLineHighlight: 'line',
-            cursorBlinking: 'smooth',
-            cursorSmoothCaretAnimation: 'on',
+            renderLineHighlight: "line",
+            cursorBlinking: "smooth",
+            cursorSmoothCaretAnimation: "on",
             smoothScrolling: true,
             bracketPairColorization: { enabled: true },
           }}
         />
       )}
     </div>
-  )
+  );
 }

--- a/packages/ui/src/hooks/useMonacoFontReady.ts
+++ b/packages/ui/src/hooks/useMonacoFontReady.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { loader } from "@monaco-editor/react";
+
+let remeasured = false;
+
+/**
+ * Waits for document fonts to finish loading, then calls Monaco's
+ * remeasureFonts() once so async web fonts (e.g. DM Mono from Google Fonts)
+ * are picked up correctly by all editor instances.
+ */
+export function useMonacoFontReady(): void {
+  useEffect(() => {
+    if (remeasured) return;
+    let cancelled = false;
+    document.fonts.ready.then(() => {
+      if (cancelled || remeasured) return;
+      remeasured = true;
+      loader.init().then((monaco) => {
+        monaco.editor.remeasureFonts();
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+}

--- a/packages/ui/src/utils/monaco-language.ts
+++ b/packages/ui/src/utils/monaco-language.ts
@@ -4,49 +4,49 @@
  * @returns Monaco language string (e.g., 'typescript', 'python', 'markdown')
  */
 export function getLanguageFromPath(filePath: string): string {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
   const map: Record<string, string> = {
-    ts: 'typescript',
-    tsx: 'typescript',
-    js: 'javascript',
-    jsx: 'javascript',
-    json: 'json',
-    md: 'markdown',
-    html: 'html',
-    css: 'css',
-    scss: 'scss',
-    sass: 'sass',
-    less: 'less',
-    py: 'python',
-    rb: 'ruby',
-    go: 'go',
-    rs: 'rust',
-    java: 'java',
-    c: 'c',
-    cpp: 'cpp',
-    h: 'c',
-    hpp: 'cpp',
-    yml: 'yaml',
-    yaml: 'yaml',
-    xml: 'xml',
-    sql: 'sql',
-    sh: 'shell',
-    bash: 'shell',
-    zsh: 'shell',
-    fish: 'shell',
-    toml: 'ini',
-    env: 'ini',
-    txt: 'plaintext',
-    php: 'php',
-    swift: 'swift',
-    kt: 'kotlin',
-    cs: 'csharp',
-    r: 'r',
-    dart: 'dart',
-    lua: 'lua',
-    dockerfile: 'dockerfile',
-  }
-  return map[ext] || 'plaintext'
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    json: "json",
+    md: "markdown",
+    html: "html",
+    css: "css",
+    scss: "scss",
+    sass: "sass",
+    less: "less",
+    py: "python",
+    rb: "ruby",
+    go: "go",
+    rs: "rust",
+    java: "java",
+    c: "c",
+    cpp: "cpp",
+    h: "c",
+    hpp: "cpp",
+    yml: "yaml",
+    yaml: "yaml",
+    xml: "xml",
+    sql: "sql",
+    sh: "shell",
+    bash: "shell",
+    zsh: "shell",
+    fish: "shell",
+    toml: "ini",
+    env: "ini",
+    txt: "plaintext",
+    php: "php",
+    swift: "swift",
+    kt: "kotlin",
+    cs: "csharp",
+    r: "r",
+    dart: "dart",
+    lua: "lua",
+    dockerfile: "dockerfile",
+  };
+  return map[ext] || "plaintext";
 }
 
 /**
@@ -55,24 +55,63 @@ export function getLanguageFromPath(filePath: string): string {
  * @returns true if the file is likely binary
  */
 export function isBinaryFile(filePath: string): boolean {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
   const binaryExts = new Set([
     // Images
-    'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico', 'svg', 'webp', 'tiff', 'tif',
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "bmp",
+    "ico",
+    "svg",
+    "webp",
+    "tiff",
+    "tif",
     // Documents
-    'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+    "pdf",
+    "doc",
+    "docx",
+    "xls",
+    "xlsx",
+    "ppt",
+    "pptx",
     // Archives
-    'zip', 'tar', 'gz', 'bz2', 'rar', '7z', 'xz',
+    "zip",
+    "tar",
+    "gz",
+    "bz2",
+    "rar",
+    "7z",
+    "xz",
     // Executables
-    'exe', 'dll', 'so', 'dylib', 'app',
+    "exe",
+    "dll",
+    "so",
+    "dylib",
+    "app",
     // Fonts
-    'woff', 'woff2', 'ttf', 'otf', 'eot',
+    "woff",
+    "woff2",
+    "ttf",
+    "otf",
+    "eot",
     // Media
-    'mp3', 'mp4', 'avi', 'mov', 'wmv', 'flv', 'wav', 'ogg',
+    "mp3",
+    "mp4",
+    "avi",
+    "mov",
+    "wmv",
+    "flv",
+    "wav",
+    "ogg",
     // Other
-    'bin', 'dat', 'db', 'sqlite',
-  ])
-  return binaryExts.has(ext)
+    "bin",
+    "dat",
+    "db",
+    "sqlite",
+  ]);
+  return binaryExts.has(ext);
 }
 
 /**
@@ -81,8 +120,8 @@ export function isBinaryFile(filePath: string): boolean {
  * @returns Number of lines
  */
 export function countLines(content: string): number {
-  if (!content) return 0
-  return content.split('\n').length
+  if (!content) return 0;
+  return content.split("\n").length;
 }
 
 /**
@@ -95,12 +134,12 @@ export function countLines(content: string): number {
 export function calculateEditorHeight(
   content: string,
   maxLines: number = 30,
-  lineHeight: number = 18
+  lineHeight: number = 18,
 ): number {
-  const lines = countLines(content)
-  const clampedLines = Math.min(lines, maxLines)
-  const padding = 40 // Top and bottom padding
-  return clampedLines * lineHeight + padding
+  const lines = countLines(content);
+  const clampedLines = Math.min(lines, maxLines);
+  const padding = 40; // Top and bottom padding
+  return clampedLines * lineHeight + padding;
 }
 
 /**
@@ -109,5 +148,9 @@ export function calculateEditorHeight(
  * @returns File name with extension
  */
 export function getFileName(filePath: string): string {
-  return filePath.split('/').pop() || filePath
+  return filePath.split("/").pop() || filePath;
 }
+
+/** Monospace font stack used across all Monaco editor instances. */
+export const MONO_FONT_FAMILY =
+  "'DM Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";

--- a/packages/ui/src/utils/path.ts
+++ b/packages/ui/src/utils/path.ts
@@ -1,0 +1,5 @@
+/** Return the last segment of a path (like POSIX basename). */
+export function basename(path: string): string {
+  const parts = path.replace(/\/+$/, "").split("/");
+  return parts[parts.length - 1] || path;
+}


### PR DESCRIPTION
## Summary
- **Fonts**: Add DM Sans (body) and DM Mono (code) via Google Fonts with correct non-variable-font URL, Tailwind `@theme inline` variables, and Monaco `remeasureFonts()` hook
- **Chat layout**: Center messages with `max-w-3xl`, remove assistant message bubble (full-width flow), simplify thinking block to minimal collapsible toggle
- **Info bar**: Show directory basenames in compact pills, move tools/tasks/file-explorer to right side
- **Thread status pills**: Working (violet, pulsing), Awaiting (amber), Done (emerald) with permission-aware state derivation
- **Code cleanup**: Extract shared `basename()` to `utils/path.ts`, `MONO_FONT_FAMILY` constant, deduplicated `useMonacoFontReady` hook, remove dead `shortenPath()`

## Test plan
- [x] `pnpm build` passes (all 3 packages)
- [x] `pnpm test` passes (103 tests across core/ui/desktop)
- [ ] Visual verification: DM Sans renders for body text, DM Mono for code/editors
- [ ] Visual verification: Monaco editors pick up DM Mono after font loads
- [ ] Visual verification: Thread status pills show correct colors for Working/Awaiting/Done states
- [ ] Visual verification: Chat messages centered, tool calls full-width within column

🤖 Generated with [Claude Code](https://claude.com/claude-code)