### PR TITLE
Ability to open a file given a hot link

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -392,6 +392,62 @@ export default function App(): React.ReactElement {
     }
   }, [preview, closePreview, openFileExplorer, activeThread]);
 
+  const handleLinkClick = useCallback(
+    (href: string) => {
+      const value = href.trim();
+      if (!value) return;
+
+      // Keep true web links in web preview.
+      if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(value)) {
+        openUrl(value);
+        return;
+      }
+
+      const hashLineMatch = value.match(/#L(\d+)(?:C(\d+))?$/i);
+      const colonLineMatch = value.match(/:(\d+)(?::(\d+))?$/);
+      const line =
+        hashLineMatch && hashLineMatch[1]
+          ? Number(hashLineMatch[1])
+          : colonLineMatch && colonLineMatch[1]
+            ? Number(colonLineMatch[1])
+            : undefined;
+      const lineNumber =
+        line && Number.isFinite(line) && line > 0 ? line : undefined;
+
+      // Remove optional line/column suffixes from file references.
+      const withoutFragment = value.replace(/#L\d+(?:C\d+)?$/i, "");
+      const withoutLine = withoutFragment.replace(/:\d+(?::\d+)?$/, "");
+
+      // Absolute local file path (macOS/Linux) -> open file explorer.
+      if (withoutLine.startsWith("/")) {
+        if (
+          activeThread?.cwd &&
+          withoutLine.startsWith(activeThread.cwd + "/")
+        ) {
+          openFileExplorer(activeThread.cwd, withoutLine, lineNumber);
+          return;
+        }
+        const lastSlash = withoutLine.lastIndexOf("/");
+        const dir =
+          lastSlash > 0 ? withoutLine.slice(0, lastSlash) : withoutLine;
+        openFileExplorer(dir, withoutLine, lineNumber);
+        return;
+      }
+
+      // Relative repo path reference -> open current thread's explorer root at exact file.
+      if (activeThread?.cwd && /^[\w./-]+$/.test(withoutLine)) {
+        const relativePath = withoutLine.replace(/^\.?\//, "");
+        const root = activeThread.cwd.replace(/\/+$/, "");
+        const targetPath = `${root}/${relativePath}`;
+        openFileExplorer(activeThread.cwd, targetPath, lineNumber);
+        return;
+      }
+
+      openUrl(value);
+    },
+    [activeThread?.cwd, openFileExplorer, openUrl],
+  );
+
   // Ctrl+Tab to cycle modes
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -579,7 +635,7 @@ export default function App(): React.ReactElement {
             <ChatView
               messages={messages}
               isStreaming={isStreaming}
-              onLinkClick={openUrl}
+              onLinkClick={handleLinkClick}
               onSendMessage={(prompt) => handleSend(prompt)}
               onQuestionAnswer={respondQuestion}
               onPlanReviewDecision={respondPlanReview}

--- a/packages/desktop/src/renderer/hooks/usePreview.ts
+++ b/packages/desktop/src/renderer/hooks/usePreview.ts
@@ -41,9 +41,19 @@ export function usePreview() {
     [],
   );
 
-  const openFileExplorer = useCallback((cwd: string) => {
-    setPreview({ isOpen: true, type: "file-explorer", title: "", cwd });
-  }, []);
+  const openFileExplorer = useCallback(
+    (cwd: string, targetFilePath?: string, targetLine?: number) => {
+      setPreview({
+        isOpen: true,
+        type: "file-explorer",
+        title: targetFilePath ?? "",
+        cwd,
+        ...(targetFilePath ? { targetFilePath } : {}),
+        ...(targetLine ? { targetLine } : {}),
+      });
+    },
+    [],
+  );
 
   const close = useCallback(() => {
     setPreview(INITIAL_STATE);

--- a/packages/ui/src/components/FileExplorer.tsx
+++ b/packages/ui/src/components/FileExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Editor } from "@monaco-editor/react";
 import { useMonacoFontReady } from "../hooks/useMonacoFontReady";
 import {
@@ -20,6 +20,8 @@ interface TreeNode {
 
 interface Props {
   cwd: string;
+  targetFilePath?: string;
+  targetLine?: number;
   listDirectory: (dirPath: string, rootPath: string) => Promise<DirEntry[]>;
   readFile: (
     filePath: string,
@@ -92,6 +94,8 @@ function Chevron({ expanded }: { expanded: boolean }) {
 
 export function FileExplorer({
   cwd,
+  targetFilePath,
+  targetLine,
   listDirectory,
   readFile,
 }: Props): React.ReactElement {
@@ -105,6 +109,12 @@ export function FileExplorer({
   } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [cursorTargetLine, setCursorTargetLine] = useState<number | null>(null);
+  const [autoOpenedTarget, setAutoOpenedTarget] = useState<string | null>(null);
+  const editorRef = useRef<{
+    revealLineInCenter: (lineNumber: number) => void;
+    setPosition: (position: { lineNumber: number; column: number }) => void;
+  } | null>(null);
 
   useEffect(() => {
     let ignored = false;
@@ -169,19 +179,21 @@ export function FileExplorer({
   );
 
   const handleFileClick = useCallback(
-    async (filePath: string, size: number) => {
-      if (size > MAX_FILE_SIZE) {
+    async (filePath: string, size?: number, line?: number) => {
+      if (size !== undefined && size > MAX_FILE_SIZE) {
         setOpenFile({
           path: filePath,
           content: "",
           isBinary: false,
           tooLarge: true,
         });
+        setCursorTargetLine(line ?? null);
         return;
       }
       try {
         const result = await readFile(filePath, cwd);
         setOpenFile({ path: filePath, ...result, tooLarge: false });
+        setCursorTargetLine(line ?? null);
       } catch (err) {
         setOpenFile({
           path: filePath,
@@ -189,12 +201,42 @@ export function FileExplorer({
           isBinary: false,
           tooLarge: false,
         });
+        setCursorTargetLine(line ?? null);
       }
     },
     [readFile, cwd],
   );
 
-  const handleBack = useCallback(() => setOpenFile(null), []);
+  const handleBack = useCallback(() => {
+    setOpenFile(null);
+    setCursorTargetLine(null);
+  }, []);
+
+  useEffect(() => {
+    setAutoOpenedTarget(null);
+    setCursorTargetLine(null);
+  }, [cwd]);
+
+  useEffect(() => {
+    if (!targetFilePath || !cwd || loading) return;
+    if (!targetFilePath.startsWith(cwd + "/")) return;
+    if (autoOpenedTarget === targetFilePath) return;
+    setAutoOpenedTarget(targetFilePath);
+    void handleFileClick(targetFilePath, undefined, targetLine);
+  }, [
+    targetFilePath,
+    targetLine,
+    cwd,
+    loading,
+    autoOpenedTarget,
+    handleFileClick,
+  ]);
+
+  useEffect(() => {
+    if (!editorRef.current || !cursorTargetLine || cursorTargetLine < 1) return;
+    editorRef.current.revealLineInCenter(cursorTargetLine);
+    editorRef.current.setPosition({ lineNumber: cursorTargetLine, column: 1 });
+  }, [cursorTargetLine, openFile?.path]);
 
   if (openFile) {
     const relativePath = openFile.path.startsWith(cwd)
@@ -244,6 +286,16 @@ export function FileExplorer({
               value={openFile.content}
               language={getLanguageFromPath(openFile.path)}
               theme="cursor-dark"
+              onMount={(editor) => {
+                editorRef.current = editor;
+                if (cursorTargetLine && cursorTargetLine > 0) {
+                  editor.revealLineInCenter(cursorTargetLine);
+                  editor.setPosition({
+                    lineNumber: cursorTargetLine,
+                    column: 1,
+                  });
+                }
+              }}
               options={{
                 readOnly: true,
                 minimap: { enabled: false },

--- a/packages/ui/src/components/PreviewPane.tsx
+++ b/packages/ui/src/components/PreviewPane.tsx
@@ -88,6 +88,8 @@ export function PreviewPane({
       {preview.type === "file-explorer" && preview.cwd && filesBridge ? (
         <FileExplorer
           cwd={preview.cwd}
+          targetFilePath={preview.targetFilePath}
+          targetLine={preview.targetLine}
           listDirectory={filesBridge.listDirectory}
           readFile={filesBridge.readFile}
         />

--- a/packages/ui/src/types/preview.ts
+++ b/packages/ui/src/types/preview.ts
@@ -13,4 +13,6 @@ export interface PreviewState {
   artifactContent?: string;
   artifactFilePath?: string;
   cwd?: string;
+  targetFilePath?: string;
+  targetLine?: number;
 }


### PR DESCRIPTION
## Summary

Improve markdown file-link behavior in chat so codebase references open the in-app file explorer correctly.

Before:
- Clicking file-like links opened the **Web** preview.

After:
- File links open the **Files** preview.
- Deep links now open the **exact file**.
- Line targeting is supported in Monaco editor.

## What Changed

### Link routing in renderer
- Added smarter link parsing in `packages/desktop/src/renderer/App.tsx`:
  - Web URLs (`http://`, `https://`, etc.) still open Web preview.
  - Local/relative file references route to Files preview.
  - Parses line suffixes from:
    - `:line`
    - `:line:column`
    - `#Lline`
    - `#LlineCcolumn`

### Preview state supports file targets
- Extended preview state in `packages/ui/src/types/preview.ts` with:
  - `targetFilePath?: string`
  - `targetLine?: number`
- Extended `openFileExplorer(...)` in `packages/desktop/src/renderer/hooks/usePreview.ts` to pass file target metadata.

### Preview pane wiring
- `packages/ui/src/components/PreviewPane.tsx` now forwards `targetFilePath` and `targetLine` into `FileExplorer`.

### File explorer deep-link open + Monaco line jump
- Updated `packages/ui/src/components/FileExplorer.tsx`:
  - Auto-opens `targetFilePath` when file explorer is opened from a deep link.
  - Sets Monaco position and reveals the target line with:
    - `revealLineInCenter(...)`
    - `setPosition(...)`

## UX Result

Clicking references like:
- `/Users/.../file.ts:58`
- `/Users/.../file.ts#L58`
- `packages/desktop/src/main/index.ts:58`

now opens Files preview, opens the exact file, and jumps to the requested line.

## Validation

- `pnpm --filter @agentpanel/ui typecheck`
- `pnpm --filter @agentpanel/desktop typecheck`