### PR TITLE
feat: add Codex connection status indicator and auth dialog

### DIFF
--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -50,6 +50,12 @@ export const IPC_CHANNELS = {
   CLAUDE_DISCONNECT: "integration:claude:disconnect",
   CLAUDE_GET_CONNECTION: "integration:claude:get-connection",
 
+  // Codex — connection management (codex app-server)
+  CODEX_CHECK_CLI: "integration:codex:check-cli",
+  CODEX_CONNECT: "integration:codex:connect",
+  CODEX_DISCONNECT: "integration:codex:disconnect",
+  CODEX_GET_CONNECTION: "integration:codex:get-connection",
+
   // Interactive tool events (AskUserQuestion, plan mode)
   ASK_USER_QUESTION: "chat:ask-user-question",
   ASK_USER_RESPONSE: "chat:ask-user-response",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -37,6 +37,7 @@ import {
   registerClaudeIpc,
   unregisterClaudeIpc,
 } from "./integrations/claude.ipc";
+import { registerCodexIpc, unregisterCodexIpc } from "./integrations/codex.ipc";
 import {
   registerDirectoryIpc,
   unregisterDirectoryIpc,
@@ -185,6 +186,7 @@ if (!gotLock) {
     registerThreadIpc();
     registerGitHubIpc(mainWindow);
     registerClaudeIpc(mainWindow);
+    registerCodexIpc(mainWindow);
     registerDirectoryIpc(mainWindow);
     registerSettingsIpc(mainWindow);
     setSlashCommandsGetter(() => agentManager?.getSlashCommands() ?? []);
@@ -218,6 +220,7 @@ if (!gotLock) {
     unregisterThreadIpc();
     unregisterGitHubIpc();
     unregisterClaudeIpc();
+    unregisterCodexIpc();
     unregisterDirectoryIpc();
     unregisterSettingsIpc();
     unregisterSkillsIpc();

--- a/packages/desktop/src/main/integrations/codex.ipc.ts
+++ b/packages/desktop/src/main/integrations/codex.ipc.ts
@@ -1,0 +1,452 @@
+import { ipcMain, shell, type BrowserWindow } from "electron";
+import { spawn, type ChildProcess } from "child_process";
+import * as readline from "readline";
+import * as path from "path";
+import * as fs from "fs";
+import { IPC_CHANNELS } from "../../common/ipc-channels";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface CodexConnectionInfo {
+  connected: boolean;
+  cliInstalled: boolean;
+  email: string | null;
+  planType: string | null;
+  authMode: string | null; // "apikey" | "chatgpt" | "chatgptAuthTokens" | null
+}
+
+// ── Cached state ────────────────────────────────────────────────────────────
+
+let cachedInfo: CodexConnectionInfo = {
+  connected: false,
+  cliInstalled: false,
+  email: null,
+  planType: null,
+  authMode: null,
+};
+
+// ── Codex binary resolution ─────────────────────────────────────────────────
+
+function findCodexBinary(): string {
+  const { platform, arch } = process;
+  let targetTriple: string | null = null;
+  switch (platform) {
+    case "linux":
+    case "android":
+      targetTriple =
+        arch === "x64"
+          ? "x86_64-unknown-linux-musl"
+          : arch === "arm64"
+            ? "aarch64-unknown-linux-musl"
+            : null;
+      break;
+    case "darwin":
+      targetTriple =
+        arch === "x64"
+          ? "x86_64-apple-darwin"
+          : arch === "arm64"
+            ? "aarch64-apple-darwin"
+            : null;
+      break;
+    case "win32":
+      targetTriple =
+        arch === "x64"
+          ? "x86_64-pc-windows-msvc"
+          : arch === "arm64"
+            ? "aarch64-pc-windows-msvc"
+            : null;
+      break;
+  }
+  if (!targetTriple)
+    throw new Error(`Unsupported platform: ${platform} (${arch})`);
+
+  const binaryName = process.platform === "win32" ? "codex.exe" : "codex";
+  const binaryRelPath = path.join("vendor", targetTriple, "codex", binaryName);
+
+  const startDirs = [
+    __dirname,
+    process.cwd(),
+    ...((process as any).resourcesPath ? [(process as any).resourcesPath] : []),
+  ].filter(Boolean);
+
+  for (const startDir of startDirs) {
+    let dir = startDir;
+    for (let i = 0; i < 10; i++) {
+      // pnpm hoisted layout
+      const pnpmDir = path.join(dir, "node_modules", ".pnpm");
+      try {
+        const entries = fs.readdirSync(pnpmDir);
+        for (const entry of entries) {
+          if (
+            entry.startsWith("@openai+codex@") &&
+            entry.includes(`-${process.platform}-`)
+          ) {
+            const candidate = path.join(
+              pnpmDir,
+              entry,
+              "node_modules",
+              "@openai",
+              "codex",
+              binaryRelPath,
+            );
+            if (fs.existsSync(candidate)) return candidate;
+          }
+        }
+      } catch {
+        // Directory doesn't exist
+      }
+
+      // Direct node_modules layout
+      const directCandidate = path.join(
+        dir,
+        "node_modules",
+        "@openai",
+        "codex",
+        binaryRelPath,
+      );
+      if (fs.existsSync(directCandidate)) return directCandidate;
+
+      // Via @openai/codex-sdk symlink
+      const sdkCandidate = path.join(
+        dir,
+        "node_modules",
+        "@openai",
+        "codex-sdk",
+        "node_modules",
+        "@openai",
+        "codex",
+        binaryRelPath,
+      );
+      if (fs.existsSync(sdkCandidate)) return sdkCandidate;
+
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  throw new Error("Unable to locate Codex CLI binary");
+}
+
+// ── App-server JSON-RPC client ──────────────────────────────────────────────
+
+let appServer: ChildProcess | undefined;
+let rl: readline.Interface | undefined;
+let rpcId = 0;
+let initialized = false;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pendingRpc = new Map<
+  number,
+  { resolve: (v: any) => void; reject: (e: Error) => void }
+>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const notificationQueue: Array<{ method: string; params: any }> = [];
+let notificationResolve: (() => void) | undefined;
+
+function sendRpc(
+  method: string,
+  params: Record<string, unknown> = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  if (!appServer?.stdin)
+    return Promise.reject(new Error("App server not running"));
+  const id = ++rpcId;
+  const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+  appServer.stdin.write(msg + "\n");
+  return new Promise((resolve, reject) => {
+    pendingRpc.set(id, { resolve, reject });
+  });
+}
+
+function sendNotification(
+  method: string,
+  params: Record<string, unknown> = {},
+): void {
+  if (!appServer?.stdin) return;
+  const msg = JSON.stringify({ jsonrpc: "2.0", method, params });
+  appServer.stdin.write(msg + "\n");
+}
+
+function waitForNotification(
+  methodName: string,
+  timeoutMs = 120_000,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+
+    function check(): void {
+      const idx = notificationQueue.findIndex((n) => n.method === methodName);
+      if (idx >= 0) {
+        const [notification] = notificationQueue.splice(idx, 1);
+        resolve(notification.params);
+        return;
+      }
+      if (Date.now() > deadline) {
+        reject(new Error(`Timeout waiting for ${methodName}`));
+        return;
+      }
+      // Wait for next notification
+      notificationResolve = () => check();
+      // Also set a fallback timer
+      setTimeout(check, 1000);
+    }
+    check();
+  });
+}
+
+async function ensureAppServer(): Promise<void> {
+  if (appServer && !appServer.killed) return;
+
+  const codexPath = findCodexBinary();
+  appServer = spawn(codexPath, ["app-server"], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env },
+  });
+
+  appServer.on("exit", () => {
+    appServer = undefined;
+    initialized = false;
+  });
+
+  appServer.stderr?.resume();
+
+  rl = readline.createInterface({
+    input: appServer.stdout!,
+    crlfDelay: Infinity,
+  });
+
+  rl.on("line", (line: string) => {
+    try {
+      const msg = JSON.parse(line);
+
+      // JSON-RPC response
+      if (msg.id !== undefined && !msg.method) {
+        const pending = pendingRpc.get(msg.id);
+        if (pending) {
+          pendingRpc.delete(msg.id);
+          if (msg.error) {
+            pending.reject(
+              new Error(msg.error.message ?? JSON.stringify(msg.error)),
+            );
+          } else {
+            pending.resolve(msg.result);
+          }
+        }
+        return;
+      }
+
+      // Notification or server request
+      if (msg.method) {
+        notificationQueue.push({
+          method: msg.method,
+          params: msg.params ?? {},
+        });
+        if (notificationResolve) {
+          notificationResolve();
+          notificationResolve = undefined;
+        }
+
+        // Auto-update cached state on account/updated
+        if (msg.method === "account/updated") {
+          const authMode = msg.params?.authMode ?? null;
+          if (authMode) {
+            cachedInfo = { ...cachedInfo, connected: true, authMode };
+          } else {
+            cachedInfo = {
+              ...cachedInfo,
+              connected: false,
+              email: null,
+              planType: null,
+              authMode: null,
+            };
+          }
+        }
+      }
+    } catch {
+      // Ignore unparseable lines
+    }
+  });
+
+  if (!initialized) {
+    await sendRpc("initialize", {
+      clientInfo: { name: "agentpanel", title: "AgentPanel", version: "0.1.0" },
+      capabilities: { experimentalApi: false },
+    });
+    sendNotification("initialized");
+    initialized = true;
+  }
+}
+
+function killAppServer(): void {
+  if (appServer && !appServer.killed) {
+    appServer.kill();
+    appServer = undefined;
+  }
+  rl?.close();
+  rl = undefined;
+  initialized = false;
+  pendingRpc.clear();
+  notificationQueue.length = 0;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function checkCliInstalled(): boolean {
+  try {
+    findCodexBinary();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkAuthStatus(): Promise<{
+  authenticated: boolean;
+  email: string | null;
+  planType: string | null;
+  authMode: string | null;
+}> {
+  try {
+    await ensureAppServer();
+    const result = await sendRpc("account/read", { refreshToken: false });
+    const account = result?.account;
+    if (account) {
+      return {
+        authenticated: true,
+        email: account.email ?? null,
+        planType: account.planType ?? null,
+        authMode: account.type ?? null,
+      };
+    }
+    return {
+      authenticated: false,
+      email: null,
+      planType: null,
+      authMode: null,
+    };
+  } catch {
+    return {
+      authenticated: false,
+      email: null,
+      planType: null,
+      authMode: null,
+    };
+  }
+}
+
+async function refreshCachedInfo(): Promise<CodexConnectionInfo> {
+  const installed = checkCliInstalled();
+  if (!installed) {
+    cachedInfo = {
+      connected: false,
+      cliInstalled: false,
+      email: null,
+      planType: null,
+      authMode: null,
+    };
+    return cachedInfo;
+  }
+
+  const authStatus = await checkAuthStatus();
+  cachedInfo = {
+    connected: authStatus.authenticated,
+    cliInstalled: true,
+    email: authStatus.email,
+    planType: authStatus.planType,
+    authMode: authStatus.authMode,
+  };
+  return cachedInfo;
+}
+
+function tryRestoreConnection(): void {
+  refreshCachedInfo().catch(() => {});
+}
+
+// ── Public getter ───────────────────────────────────────────────────────────
+
+export function getCodexConnectionInfo(): CodexConnectionInfo {
+  return cachedInfo;
+}
+
+// ── IPC Registration ────────────────────────────────────────────────────────
+
+export function registerCodexIpc(_window: BrowserWindow): void {
+  tryRestoreConnection();
+
+  ipcMain.handle(IPC_CHANNELS.CODEX_CHECK_CLI, () => {
+    return { installed: checkCliInstalled() };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CODEX_CONNECT, async () => {
+    try {
+      if (!checkCliInstalled()) {
+        return { ok: false, error: "Codex CLI is not installed" };
+      }
+
+      await ensureAppServer();
+
+      // Start ChatGPT OAuth flow
+      const loginResult = await sendRpc("account/login/start", {
+        type: "chatgpt",
+      });
+
+      if (loginResult?.authUrl) {
+        await shell.openExternal(loginResult.authUrl);
+      }
+
+      // Wait for login completion notification
+      const completion = await waitForNotification(
+        "account/login/completed",
+        120_000,
+      );
+
+      if (!completion?.success) {
+        return { ok: false, error: completion?.error ?? "Login failed" };
+      }
+
+      const info = await refreshCachedInfo();
+      return {
+        ok: true,
+        email: info.email,
+        planType: info.planType,
+        authMode: info.authMode,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : "Authentication failed",
+      };
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CODEX_DISCONNECT, async () => {
+    try {
+      await ensureAppServer();
+      await sendRpc("account/logout");
+    } catch {
+      // Best-effort
+    }
+    cachedInfo = {
+      connected: false,
+      cliInstalled: cachedInfo.cliInstalled,
+      email: null,
+      planType: null,
+      authMode: null,
+    };
+    return { ok: true };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CODEX_GET_CONNECTION, async () => {
+    await refreshCachedInfo();
+    return cachedInfo;
+  });
+}
+
+export function unregisterCodexIpc(): void {
+  ipcMain.removeHandler(IPC_CHANNELS.CODEX_CHECK_CLI);
+  ipcMain.removeHandler(IPC_CHANNELS.CODEX_CONNECT);
+  ipcMain.removeHandler(IPC_CHANNELS.CODEX_DISCONNECT);
+  ipcMain.removeHandler(IPC_CHANNELS.CODEX_GET_CONNECTION);
+  killAppServer();
+}

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -192,6 +192,16 @@ const api = {
   claudeGetConnection: (): Promise<unknown> =>
     ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_GET_CONNECTION),
 
+  // Codex — connection management (codex app-server)
+  codexCheckCli: (): Promise<unknown> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CODEX_CHECK_CLI),
+  codexConnect: (): Promise<unknown> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CODEX_CONNECT),
+  codexDisconnect: (): Promise<unknown> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CODEX_DISCONNECT),
+  codexGetConnection: (): Promise<unknown> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CODEX_GET_CONNECTION),
+
   // Folders
   foldersList: (): Promise<Folder[]> =>
     ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_LIST),
@@ -210,8 +220,19 @@ const api = {
   threadsGetActive: () => ipcRenderer.invoke(IPC_CHANNELS.THREADS_GET_ACTIVE),
   threadsSetActive: (threadId: string | null) =>
     ipcRenderer.invoke(IPC_CHANNELS.THREADS_SET_ACTIVE, threadId),
-  threadsCreate: (title?: string, model?: string, cwd?: string, provider?: string) =>
-    ipcRenderer.invoke(IPC_CHANNELS.THREADS_CREATE, title, model, cwd, provider),
+  threadsCreate: (
+    title?: string,
+    model?: string,
+    cwd?: string,
+    provider?: string,
+  ) =>
+    ipcRenderer.invoke(
+      IPC_CHANNELS.THREADS_CREATE,
+      title,
+      model,
+      cwd,
+      provider,
+    ),
   threadsGet: (threadId: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.THREADS_GET, threadId),
   threadsUpdate: (

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -25,9 +25,11 @@ import { useThreads } from "./hooks/useThreads";
 import { useFolders } from "./hooks/useFolders";
 import { useGitHub } from "./hooks/useGitHub";
 import { useClaude } from "./hooks/useClaude";
+import { useCodex } from "./hooks/useCodex";
 import { usePreview } from "./hooks/usePreview";
 import { ConnectGitHubDialog } from "./components/ConnectGitHubDialog";
 import { ConnectClaudeDialog } from "./components/ConnectClaudeDialog";
+import { ConnectCodexDialog } from "./components/ConnectCodexDialog";
 import { SettingsDialog } from "./components/SettingsDialog";
 
 function ContextRing({
@@ -141,6 +143,7 @@ export default function App(): React.ReactElement {
 
   const github = useGitHub();
   const claude = useClaude();
+  const codex = useCodex();
   const {
     preview,
     openUrl,
@@ -154,6 +157,7 @@ export default function App(): React.ReactElement {
 
   const [showClaudeDialog, setShowClaudeDialog] = useState(false);
   const [showGitHubDialog, setShowGitHubDialog] = useState(false);
+  const [showCodexDialog, setShowCodexDialog] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [pendingMode, setPendingMode] = useState<AgentMode>();
   const [pendingProvider, setPendingProvider] = useState<
@@ -608,6 +612,24 @@ export default function App(): React.ReactElement {
                     GitHub
                   </span>
                 </button>
+                <button
+                  onClick={() => setShowCodexDialog(true)}
+                  className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[#2a2a2a]"
+                  title={
+                    codex.isConnected ? "Codex connected" : "Connect Codex"
+                  }
+                >
+                  <div
+                    className={`w-1.5 h-1.5 rounded-full ${codex.isConnected ? "bg-green-500" : "bg-gray-600"}`}
+                  />
+                  <span
+                    className={
+                      codex.isConnected ? "text-gray-400" : "text-gray-600"
+                    }
+                  >
+                    Codex
+                  </span>
+                </button>
               </div>
             </div>
 
@@ -741,6 +763,21 @@ export default function App(): React.ReactElement {
         onClose={() => setShowClaudeDialog(false)}
         onConnect={claude.connect}
         onDisconnect={claude.disconnect}
+      />
+
+      {/* Codex connect dialog */}
+      <ConnectCodexDialog
+        isOpen={showCodexDialog}
+        isConnected={codex.isConnected}
+        cliInstalled={codex.cliInstalled}
+        email={codex.email}
+        planType={codex.planType}
+        authMode={codex.authMode}
+        loading={codex.loading}
+        error={codex.error}
+        onClose={() => setShowCodexDialog(false)}
+        onConnect={codex.connect}
+        onDisconnect={codex.disconnect}
       />
 
       {/* GitHub connect dialog */}

--- a/packages/desktop/src/renderer/components/ConnectCodexDialog.tsx
+++ b/packages/desktop/src/renderer/components/ConnectCodexDialog.tsx
@@ -1,0 +1,230 @@
+import { useState, useCallback } from "react";
+import {
+  Dialog,
+  DialogBody,
+  Button,
+  StatusIndicator,
+  Card,
+} from "@agentpanel/ui";
+
+interface Props {
+  isOpen: boolean;
+  isConnected: boolean;
+  cliInstalled: boolean;
+  email: string | null;
+  planType: string | null;
+  authMode: string | null;
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onConnect: () => Promise<{ ok: boolean; error?: string }>;
+  onDisconnect: () => Promise<void>;
+}
+
+export function ConnectCodexDialog({
+  isOpen,
+  isConnected,
+  cliInstalled,
+  email,
+  planType,
+  authMode,
+  loading: externalLoading,
+  error: externalError,
+  onClose,
+  onConnect,
+  onDisconnect,
+}: Props): React.ReactElement | null {
+  const [localLoading, setLocalLoading] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const loading = externalLoading || localLoading;
+  const error = localError ?? externalError;
+
+  const handleConnect = useCallback(async () => {
+    setLocalLoading(true);
+    setLocalError(null);
+    try {
+      const result = await onConnect();
+      if (!result.ok) {
+        setLocalError(result.error ?? "Failed to connect");
+      } else {
+        onClose();
+      }
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Connection failed");
+    } finally {
+      setLocalLoading(false);
+    }
+  }, [onConnect, onClose]);
+
+  const handleDisconnect = useCallback(async () => {
+    setLocalLoading(true);
+    setLocalError(null);
+    await onDisconnect();
+    setLocalLoading(false);
+  }, [onDisconnect]);
+
+  const icon = (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4 text-white">
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364l2.0201-1.1638a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4114-.6878zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997z" />
+    </svg>
+  );
+
+  const authModeLabel =
+    authMode === "apikey"
+      ? "API Key"
+      : authMode === "chatgpt"
+        ? "ChatGPT"
+        : authMode;
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Codex"
+      subtitle="Authentication & account"
+      icon={icon}
+      iconGradient="from-green-600 to-emerald-700"
+      maxWidth="sm"
+    >
+      <DialogBody>
+        {isConnected ? (
+          <>
+            <StatusIndicator
+              status="connected"
+              label="Connected"
+              className="mb-4"
+            />
+
+            <Card variant="nested" className="mb-4">
+              {email && (
+                <>
+                  <div className="text-xs text-gray-500 mb-1">Account</div>
+                  <div className="text-sm text-gray-300 mb-3">{email}</div>
+                </>
+              )}
+              {planType && (
+                <>
+                  <div className="text-xs text-gray-500 mb-1">Plan</div>
+                  <div className="text-sm text-gray-300 mb-3 capitalize">
+                    {planType}
+                  </div>
+                </>
+              )}
+              {authModeLabel && (
+                <>
+                  <div className="text-xs text-gray-500 mb-1">Auth mode</div>
+                  <div className="text-sm text-gray-300 capitalize">
+                    {authModeLabel}
+                  </div>
+                </>
+              )}
+            </Card>
+
+            <div className="mb-4 p-3 bg-[#1a1a1a] rounded-lg">
+              <p className="text-xs text-gray-400">
+                Codex uses your OpenAI account for authentication. Signing out
+                will require re-authentication to continue using Codex.
+              </p>
+            </div>
+
+            <Button
+              variant="destructive"
+              onClick={handleDisconnect}
+              disabled={loading}
+              loading={loading}
+              className="w-full"
+            >
+              Sign out
+            </Button>
+          </>
+        ) : !cliInstalled ? (
+          <>
+            <div className="mb-4 p-3 bg-yellow-900/20 border border-yellow-500/20 rounded-lg">
+              <p className="text-xs text-yellow-400 font-medium mb-1">
+                Codex CLI not found
+              </p>
+              <p className="text-xs text-yellow-400/80">
+                Install the <code className="text-yellow-300">codex</code> CLI
+                to connect your account.
+              </p>
+            </div>
+
+            <div className="mb-4 p-3 bg-[#1a1a1a] rounded-lg">
+              <p className="text-xs text-gray-500 mb-2">Install via npm:</p>
+              <code className="text-xs text-gray-300 bg-[#0f0f0f] px-2 py-1 rounded block">
+                npm install -g @openai/codex
+              </code>
+            </div>
+
+            {error && (
+              <div className="mb-4 p-3 bg-red-900/20 border border-red-500/20 rounded-lg">
+                <p className="text-xs text-red-400">{error}</p>
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <p className="text-xs text-gray-500 mb-5">
+              Sign in with your ChatGPT account to authenticate. This opens your
+              browser to complete the OAuth flow.
+            </p>
+
+            {error && (
+              <div className="mb-4 p-3 bg-red-900/20 border border-red-500/20 rounded-lg">
+                <p className="text-xs text-red-400">{error}</p>
+              </div>
+            )}
+
+            <button
+              onClick={handleConnect}
+              disabled={loading}
+              className="w-full py-3 px-4 rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 text-white text-sm font-medium hover:from-green-500 hover:to-emerald-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-3"
+            >
+              {loading ? (
+                <span className="flex items-center gap-2">
+                  <svg
+                    className="animate-spin h-4 w-4 text-white/60"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      fill="none"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                  <span className="text-white/60">Waiting for sign-in...</span>
+                </span>
+              ) : (
+                <>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364l2.0201-1.1638a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4114-.6878zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997z" />
+                  </svg>
+                  Sign in with ChatGPT
+                </>
+              )}
+            </button>
+
+            <p className="text-[10px] text-gray-600 mt-3 text-center">
+              Your browser will open to complete authentication.
+            </p>
+          </>
+        )}
+      </DialogBody>
+    </Dialog>
+  );
+}

--- a/packages/desktop/src/renderer/hooks/useCodex.ts
+++ b/packages/desktop/src/renderer/hooks/useCodex.ts
@@ -1,0 +1,110 @@
+import { useState, useCallback, useEffect } from "react";
+
+interface ConnectionStatus {
+  connected: boolean;
+  cliInstalled: boolean;
+  email: string | null;
+  planType: string | null;
+  authMode: string | null;
+}
+
+interface UseCodexReturn {
+  isConnected: boolean;
+  cliInstalled: boolean;
+  email: string | null;
+  planType: string | null;
+  authMode: string | null;
+  loading: boolean;
+  error: string | null;
+  connect: () => Promise<{ ok: boolean; error?: string }>;
+  disconnect: () => Promise<void>;
+  refreshConnection: () => Promise<void>;
+}
+
+export function useCodex(): UseCodexReturn {
+  const [isConnected, setIsConnected] = useState(false);
+  const [cliInstalled, setCliInstalled] = useState(false);
+  const [email, setEmail] = useState<string | null>(null);
+  const [planType, setPlanType] = useState<string | null>(null);
+  const [authMode, setAuthMode] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshConnection = useCallback(async () => {
+    try {
+      const status =
+        (await window.api.codexGetConnection()) as ConnectionStatus;
+      setIsConnected(status.connected);
+      setCliInstalled(status.cliInstalled);
+      setEmail(status.email);
+      setPlanType(status.planType);
+      setAuthMode(status.authMode);
+    } catch {
+      setIsConnected(false);
+      setCliInstalled(false);
+      setEmail(null);
+      setPlanType(null);
+      setAuthMode(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshConnection();
+  }, [refreshConnection]);
+
+  const connect = useCallback(async (): Promise<{
+    ok: boolean;
+    error?: string;
+  }> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = (await window.api.codexConnect()) as
+        | { ok: true; email?: string; planType?: string; authMode?: string }
+        | { ok: false; error: string };
+      if (result.ok) {
+        await refreshConnection();
+        return { ok: true };
+      }
+      const errMsg =
+        typeof result.error === "string" ? result.error : "Connection failed";
+      setError(errMsg);
+      return { ok: false, error: errMsg };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Connection failed";
+      setError(msg);
+      return { ok: false, error: msg };
+    } finally {
+      setLoading(false);
+    }
+  }, [refreshConnection]);
+
+  const disconnect = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await window.api.codexDisconnect();
+      setIsConnected(false);
+      setEmail(null);
+      setPlanType(null);
+      setAuthMode(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to disconnect");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    isConnected,
+    cliInstalled,
+    email,
+    planType,
+    authMode,
+    loading,
+    error,
+    connect,
+    disconnect,
+    refreshConnection,
+  };
+}


### PR DESCRIPTION
Uses the Codex app-server JSON-RPC protocol (account/read, account/login/start, account/logout) to check auth state, trigger ChatGPT OAuth login, and sign out. Adds a status dot in the toolbar alongside Claude and GitHub.