### PR TITLE
feat: add Always Allow permission button using SDK suggestions

### DIFF
--- a/packages/core/src/__tests__/claude-code.provider.integration.test.ts
+++ b/packages/core/src/__tests__/claude-code.provider.integration.test.ts
@@ -281,11 +281,19 @@ describe("ClaudeCodeProvider integration (fake SDK)", () => {
           canUseTool?: (
             name: string,
             input: Record<string, unknown>,
+            sdkOptions: unknown,
           ) => Promise<unknown>;
         };
       }) => {
         if (options?.canUseTool) {
-          options.canUseTool("Bash", { command: "ls" });
+          options.canUseTool(
+            "Bash",
+            { command: "ls" },
+            {
+              signal: new AbortController().signal,
+              toolUseID: "test-tool-use-id",
+            },
+          );
         }
         return makeStream([]);
       },
@@ -302,7 +310,14 @@ describe("ClaudeCodeProvider integration (fake SDK)", () => {
       msgs.push(msg);
     }
 
-    expect(permissionHandler).toHaveBeenCalledWith("Bash", { command: "ls" });
+    expect(permissionHandler).toHaveBeenCalledWith(
+      "Bash",
+      { command: "ls" },
+      {
+        suggestions: undefined,
+        decisionReason: undefined,
+      },
+    );
   });
 
   it("uses default tools in plan mode (SDK handles restrictions)", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export type {
   SendMessageParams,
   AgentDefinition,
   PermissionHandler,
+  PermissionUpdate,
   TokenUsage,
   ModelInfo,
   TodoItem,

--- a/packages/core/src/providers/claude-code.provider.ts
+++ b/packages/core/src/providers/claude-code.provider.ts
@@ -82,12 +82,28 @@ export class ClaudeCodeProvider implements AgentProvider {
         | "acceptEdits"
         | "bypassPermissions",
       ...(isBypass ? { allowDangerouslySkipPermissions: true } : {}),
-      canUseTool: async (toolName: string, input: Record<string, unknown>) => {
-        const result = await params.permissionHandler(toolName, input);
+      canUseTool: async (
+        toolName: string,
+        input: Record<string, unknown>,
+        sdkOptions: {
+          signal: AbortSignal;
+          suggestions?: unknown[];
+          decisionReason?: string;
+          toolUseID: string;
+          agentID?: string;
+        },
+      ) => {
+        const result = await params.permissionHandler(toolName, input, {
+          suggestions: sdkOptions.suggestions,
+          decisionReason: sdkOptions.decisionReason,
+        });
         if (result.approved) {
           return {
             behavior: "allow" as const,
             updatedInput: result.modifiedInput ?? input,
+            ...(result.updatedPermissions
+              ? { updatedPermissions: result.updatedPermissions }
+              : {}),
           };
         }
         return {

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -98,13 +98,22 @@ export interface SendMessageParams {
   traceCallback?: (entry: any) => void;
 }
 
+/** Opaque permission update passed through from the SDK */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PermissionUpdate = any;
+
 export type PermissionHandler = (
   toolName: string,
   input: Record<string, unknown>,
+  options?: {
+    suggestions?: PermissionUpdate[];
+    decisionReason?: string;
+  },
 ) => Promise<{
   approved: boolean;
   modifiedInput?: Record<string, unknown>;
   denyMessage?: string;
+  updatedPermissions?: PermissionUpdate[];
 }>;
 
 export interface ProviderConfig {

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -97,6 +97,8 @@ export class AgentManager {
         approved: boolean;
         modifiedInput?: Record<string, unknown>;
         denyMessage?: string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        updatedPermissions?: any[];
       }) => void;
     }
   >();
@@ -188,10 +190,20 @@ export class AgentManager {
     // Handle tool permission responses from the renderer
     ipcMain.on(
       IPC_CHANNELS.TOOL_RESPONSE,
-      (_event, data: { requestId: string; approved: boolean }) => {
+      (
+        _event,
+        data: {
+          requestId: string;
+          approved: boolean;
+          updatedPermissions?: unknown[];
+        },
+      ) => {
         const pending = this.pendingPermissions.get(data.requestId);
         if (pending) {
-          pending.resolve({ approved: data.approved });
+          pending.resolve({
+            approved: data.approved,
+            updatedPermissions: data.updatedPermissions,
+          });
           this.pendingPermissions.delete(data.requestId);
         }
       },
@@ -416,7 +428,11 @@ export class AgentManager {
       isRunning: true,
     });
 
-    const permissionHandler: PermissionHandler = async (toolName, input) => {
+    const permissionHandler: PermissionHandler = async (
+      toolName,
+      input,
+      options,
+    ) => {
       const currentThread = await this.storage.getThread(threadId);
       const currentMode = normalizeMode(currentThread?.mode);
 
@@ -440,7 +456,13 @@ export class AgentManager {
       const requestId = `perm_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       this.sendToRenderer(
         IPC_CHANNELS.TOOL_PERMISSION,
-        { requestId, toolName, input },
+        {
+          requestId,
+          toolName,
+          input,
+          suggestions: options?.suggestions,
+          decisionReason: options?.decisionReason,
+        },
         threadId,
       );
       this.notifyIfBackground(threadId, "permission");

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -43,8 +43,16 @@ const api = {
     );
   },
 
-  respondToolPermission: (requestId: string, approved: boolean): void => {
-    ipcRenderer.send(IPC_CHANNELS.TOOL_RESPONSE, { requestId, approved });
+  respondToolPermission: (
+    requestId: string,
+    approved: boolean,
+    updatedPermissions?: unknown[],
+  ): void => {
+    ipcRenderer.send(IPC_CHANNELS.TOOL_RESPONSE, {
+      requestId,
+      approved,
+      updatedPermissions,
+    });
   },
 
   onSessionReady: (

--- a/packages/desktop/src/renderer/hooks/__tests__/useChat.test.tsx
+++ b/packages/desktop/src/renderer/hooks/__tests__/useChat.test.tsx
@@ -324,7 +324,11 @@ describe("useChat — respondPermission", () => {
       result.current.respondPermission("req-1", true);
     });
 
-    expect(mockApi.respondToolPermission).toHaveBeenCalledWith("req-1", true);
+    expect(mockApi.respondToolPermission).toHaveBeenCalledWith(
+      "req-1",
+      true,
+      undefined,
+    );
   });
 
   it("calls respondToolPermission with approved=false", () => {
@@ -334,7 +338,11 @@ describe("useChat — respondPermission", () => {
       result.current.respondPermission("req-1", false);
     });
 
-    expect(mockApi.respondToolPermission).toHaveBeenCalledWith("req-1", false);
+    expect(mockApi.respondToolPermission).toHaveBeenCalledWith(
+      "req-1",
+      false,
+      undefined,
+    );
   });
 });
 

--- a/packages/desktop/src/renderer/hooks/useChat.ts
+++ b/packages/desktop/src/renderer/hooks/useChat.ts
@@ -40,7 +40,11 @@ interface UseChatReturn {
     images?: ImageAttachment[],
   ) => Promise<void>;
   interrupt: (threadId?: string) => Promise<void>;
-  respondPermission: (requestId: string, approved: boolean) => void;
+  respondPermission: (
+    requestId: string,
+    approved: boolean,
+    updatedPermissions?: unknown[],
+  ) => void;
   respondQuestion: (requestId: string, answers: Record<string, string>) => void;
   respondPlanReview: (
     requestId: string,
@@ -998,8 +1002,8 @@ export function useChat(
   );
 
   const respondPermission = useCallback(
-    (requestId: string, approved: boolean) => {
-      window.api.respondToolPermission(requestId, approved);
+    (requestId: string, approved: boolean, updatedPermissions?: unknown[]) => {
+      window.api.respondToolPermission(requestId, approved, updatedPermissions);
       setPermissionRequests((prev) =>
         prev.filter((r) => r.requestId !== requestId),
       );

--- a/packages/ui/src/bridges/types.ts
+++ b/packages/ui/src/bridges/types.ts
@@ -15,7 +15,11 @@ export interface ChatBridge {
     sessionId?: string,
   ): void;
   interrupt(threadId?: string): void;
-  respondPermission(requestId: string, approved: boolean): void;
+  respondPermission(
+    requestId: string,
+    approved: boolean,
+    updatedPermissions?: unknown[],
+  ): void;
   respondQuestion(requestId: string, answers: Record<string, string>): void;
   respondPlanReview(
     requestId: string,

--- a/packages/ui/src/components/PermissionDialog.tsx
+++ b/packages/ui/src/components/PermissionDialog.tsx
@@ -1,24 +1,35 @@
-import type { PermissionRequest } from '../types'
+import type { PermissionRequest } from "../types";
 
 interface Props {
-  request: PermissionRequest
-  onRespond: (requestId: string, approved: boolean) => void
+  request: PermissionRequest;
+  onRespond: (
+    requestId: string,
+    approved: boolean,
+    updatedPermissions?: unknown[],
+  ) => void;
 }
 
 function formatInput(input: Record<string, unknown>): string {
   try {
-    return JSON.stringify(input, null, 2)
+    return JSON.stringify(input, null, 2);
   } catch {
-    return String(input)
+    return String(input);
   }
 }
 
-export function PermissionDialog({ request, onRespond }: Props): React.ReactElement {
+export function PermissionDialog({
+  request,
+  onRespond,
+}: Props): React.ReactElement {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <div className="bg-[#1a1a1a] border border-[#333] rounded-2xl p-6 max-w-lg w-full mx-4 shadow-2xl">
-        <h3 className="text-lg font-semibold text-gray-200 mb-1">Tool Permission Request</h3>
-        <p className="text-sm text-gray-400 mb-4">The assistant wants to use the following tool:</p>
+        <h3 className="text-lg font-semibold text-gray-200 mb-1">
+          Tool Permission Request
+        </h3>
+        <p className="text-sm text-gray-400 mb-4">
+          The assistant wants to use the following tool:
+        </p>
 
         <div className="bg-[#111] border border-[#2a2a2a] rounded-xl p-4 mb-4">
           <div className="flex items-center gap-2 mb-3">
@@ -26,6 +37,11 @@ export function PermissionDialog({ request, onRespond }: Props): React.ReactElem
               {request.toolName}
             </span>
           </div>
+          {request.decisionReason && (
+            <p className="text-xs text-gray-500 mb-2">
+              {request.decisionReason}
+            </p>
+          )}
           <pre className="text-xs text-gray-400 font-mono overflow-x-auto max-h-60 overflow-y-auto whitespace-pre-wrap">
             {formatInput(request.input)}
           </pre>
@@ -38,6 +54,16 @@ export function PermissionDialog({ request, onRespond }: Props): React.ReactElem
           >
             Deny
           </button>
+          {request.suggestions && request.suggestions.length > 0 && (
+            <button
+              onClick={() =>
+                onRespond(request.requestId, true, request.suggestions)
+              }
+              className="px-4 py-2 text-sm rounded-lg bg-[#2a2a2a] hover:bg-[#444] text-green-400 border border-green-600/30 transition-colors"
+            >
+              Always Allow
+            </button>
+          )}
           <button
             onClick={() => onRespond(request.requestId, true)}
             className="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors"
@@ -47,5 +73,5 @@ export function PermissionDialog({ request, onRespond }: Props): React.ReactElem
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -1,102 +1,111 @@
-import type { AgentMode } from '@agentpanel/core'
+import type { AgentMode } from "@agentpanel/core";
 
-export type { Thread, StoredMessage, StoredToolCall, StoredImageAttachment, AgentMode } from '@agentpanel/core'
+export type {
+  Thread,
+  StoredMessage,
+  StoredToolCall,
+  StoredImageAttachment,
+  AgentMode,
+} from "@agentpanel/core";
 
 export interface AskUserQuestionRequest {
-  requestId: string
+  requestId: string;
   input: {
     questions: Array<{
-      question: string
-      header?: string
-      options: Array<{ label: string; description?: string }>
-      multiSelect: boolean
-    }>
-  }
+      question: string;
+      header?: string;
+      options: Array<{ label: string; description?: string }>;
+      multiSelect: boolean;
+    }>;
+  };
 }
 
 export interface PlanReviewRequest {
-  requestId: string
-  input: { allowedPrompts?: Array<{ tool: string; prompt: string }> }
-  planContent?: string
-  planTitle?: string
+  requestId: string;
+  input: { allowedPrompts?: Array<{ tool: string; prompt: string }> };
+  planContent?: string;
+  planTitle?: string;
 }
 
 export interface ImageAttachment {
-  id: string
-  name: string
-  dataUrl: string
-  mimeType: string
+  id: string;
+  name: string;
+  dataUrl: string;
+  mimeType: string;
 }
 
 export interface TodoItem {
-  content: string
-  status: 'pending' | 'in_progress' | 'completed'
-  activeForm: string
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+  activeForm: string;
 }
 
 export interface TodoData {
-  todos: TodoItem[]
+  todos: TodoItem[];
 }
 
 export interface WorktreeProgressStep {
-  step: string
-  status: 'running' | 'completed' | 'error'
+  step: string;
+  status: "running" | "completed" | "error";
 }
 
 export interface WorktreeProgressData {
-  steps: WorktreeProgressStep[]
+  steps: WorktreeProgressStep[];
 }
 
 export interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  timestamp: number
-  toolCalls?: ToolCall[]
-  taskInfo?: TaskInfo
-  cost?: number
-  usage?: { inputTokens: number; outputTokens: number }
-  contextWindow?: number
-  thinking?: string
-  questionData?: AskUserQuestionRequest
-  questionAnswered?: boolean
-  planReviewData?: PlanReviewRequest
-  todoData?: TodoData
-  worktreeProgress?: WorktreeProgressData
-  modeChange?: AgentMode
-  images?: ImageAttachment[]
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: number;
+  toolCalls?: ToolCall[];
+  taskInfo?: TaskInfo;
+  cost?: number;
+  usage?: { inputTokens: number; outputTokens: number };
+  contextWindow?: number;
+  thinking?: string;
+  questionData?: AskUserQuestionRequest;
+  questionAnswered?: boolean;
+  planReviewData?: PlanReviewRequest;
+  todoData?: TodoData;
+  worktreeProgress?: WorktreeProgressData;
+  modeChange?: AgentMode;
+  images?: ImageAttachment[];
 }
 
 export interface ToolCall {
-  toolCallId: string
-  toolName: string
-  input: Record<string, unknown>
-  output?: string
-  status: 'pending' | 'running' | 'completed' | 'denied'
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  output?: string;
+  status: "pending" | "running" | "completed" | "denied";
 }
 
 export interface TaskInfo {
-  taskId: string
-  subagentType: string
-  description: string
-  prompt: string
-  status: 'running' | 'completed' | 'error'
-  childToolCalls: string[]
-  startTime: number
-  endTime?: number
-  result?: string
-  toolCallsExpanded?: boolean
+  taskId: string;
+  subagentType: string;
+  description: string;
+  prompt: string;
+  status: "running" | "completed" | "error";
+  childToolCalls: string[];
+  startTime: number;
+  endTime?: number;
+  result?: string;
+  toolCallsExpanded?: boolean;
 }
 
 export interface PermissionRequest {
-  requestId: string
-  toolName: string
-  input: Record<string, unknown>
-  threadId?: string | null
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  threadId?: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  suggestions?: any[];
+  decisionReason?: string;
 }
 
 export interface ModelInfo {
-  value: string
-  displayName: string
-  description: string
+  value: string;
+  displayName: string;
+  description: string;
 }


### PR DESCRIPTION
## Summary
- Thread the SDK's `suggestions` and `decisionReason` through the entire permission flow (provider → IPC → dialog → back)
- Add an "Always Allow" button to the permission dialog that returns `updatedPermissions` to the SDK, enabling session-level permission memory
- When clicked, the SDK remembers the approval rule and auto-approves matching tools for the rest of the session

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (all 3 packages)
- [ ] Start with `pnpm --filter @agentpanel/desktop dev:debug` in Default mode
- [ ] Trigger a tool permission → verify "Always Allow" button appears alongside "Deny" and "Approve"
- [ ] Click "Always Allow" → verify the same tool type no longer prompts
- [ ] Click "Approve" → verify it still prompts next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)