### PR TITLE
feat: add dev:fullscreen mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "turbo dev --filter=@agentpanel/core --filter=@agentpanel/ui --filter=@agentpanel/desktop",
+    "dev:fullscreen": "turbo dev:fullscreen --filter=@agentpanel/desktop",
     "build": "turbo build",
     "test": "turbo test",
     "typecheck": "turbo typecheck",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -6,6 +6,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "dev:fullscreen": "FULLSCREEN=1 electron-vite dev",
     "dev:debug": "ENABLE_CDP=1 electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -107,6 +107,7 @@ if (!gotLock) {
       minWidth: 600,
       minHeight: 400,
       show: false,
+      ...(process.env.FULLSCREEN === "1" && { fullscreen: true }),
       title: worktree ? `AgentPanel — ${worktree.name}` : "AgentPanel",
       titleBarStyle: "hiddenInset",
       transparent: true,

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "persistent": true,
       "cache": false
     },
+    "dev:fullscreen": {
+      "persistent": true,
+      "cache": false
+    },
     "test": {},
     "typecheck": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Summary

- Adds `pnpm dev:fullscreen` (root) and `pnpm --filter @agentpanel/desktop dev:fullscreen` commands
- Sets `FULLSCREEN=1` env var which makes Electron open the window in fullscreen
- Registers the task in `turbo.json` so Turbo can find it
- `pnpm dev` is completely unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)