### PR TITLE
Separate model and effort dropdown backgrounds

### DIFF
--- a/packages/ui/src/components/ModelSelector.tsx
+++ b/packages/ui/src/components/ModelSelector.tsx
@@ -132,61 +132,62 @@ export default function ModelSelector({
     currentModelInfo?.supportsReasoning ?? isOpusModel(currentModelInfo);
 
   return (
-    <div className="flex items-center gap-1 bg-[var(--bg-surface)] border border-[var(--border)] rounded-lg px-2 py-0.5">
-      <div className="relative" ref={dropdownRef}>
-        <button
-          onClick={() => setIsOpen((v) => !v)}
-          className="flex items-center gap-1 text-xs text-[var(--text-control)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
-          title={currentModelInfo?.description}
-        >
-          {currentModelInfo?.displayName ?? currentModel}
-          <svg
-            className="w-3 h-3"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            viewBox="0 0 24 24"
+    <div className="flex items-center gap-1.5">
+      <div className="bg-[var(--bg-surface)] border border-[var(--border)] rounded-lg px-2 py-0.5">
+        <div className="relative" ref={dropdownRef}>
+          <button
+            onClick={() => setIsOpen((v) => !v)}
+            className="flex items-center gap-1 text-xs text-[var(--text-control)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+            title={currentModelInfo?.description}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </button>
+            {currentModelInfo?.displayName ?? currentModel}
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
 
-        {isOpen && (
-          <div className="absolute bottom-full mb-1 left-0 z-50 min-w-48 bg-[var(--bg-surface)] border border-[var(--border-mid)] rounded-lg shadow-xl overflow-hidden">
-            {models.map((model, i) => (
-              <button
-                key={model.value}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  onModelChange(model.value);
-                  setIsOpen(false);
-                }}
-                onMouseEnter={() => setHighlightedIndex(i)}
-                className={`w-full text-left px-3 py-2 text-xs flex flex-col gap-0.5 ${
-                  i === highlightedIndex
-                    ? "bg-[var(--border)] text-[var(--text-primary)]"
-                    : "text-[var(--text-control)] hover:bg-[var(--border)]"
-                }`}
-              >
-                <span>{model.displayName}</span>
-                {model.description && (
-                  <span className="text-[var(--text-muted)] text-[11px]">
-                    {model.description}
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
-        )}
+          {isOpen && (
+            <div className="absolute bottom-full mb-1 left-0 z-50 min-w-48 bg-[var(--bg-surface)] border border-[var(--border-mid)] rounded-lg shadow-xl overflow-hidden">
+              {models.map((model, i) => (
+                <button
+                  key={model.value}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onModelChange(model.value);
+                    setIsOpen(false);
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(i)}
+                  className={`w-full text-left px-3 py-2 text-xs flex flex-col gap-0.5 ${
+                    i === highlightedIndex
+                      ? "bg-[var(--border)] text-[var(--text-primary)]"
+                      : "text-[var(--text-control)] hover:bg-[var(--border)]"
+                  }`}
+                >
+                  <span>{model.displayName}</span>
+                  {model.description && (
+                    <span className="text-[var(--text-muted)] text-[11px]">
+                      {model.description}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {showEffort && (
-        <>
-          <span className="text-xs text-[var(--text-muted)]">·</span>
+        <div className="bg-[var(--bg-surface)] border border-[var(--border)] rounded-lg px-2 py-0.5">
           <label className="inline-flex items-center gap-0.5 cursor-pointer text-[var(--text-control)] hover:text-[var(--text-primary)] transition-colors">
             <select
               value={thinkingEffort || "high"}
@@ -214,7 +215,7 @@ export default function ModelSelector({
               />
             </svg>
           </label>
-        </>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Split the model selector and thinking effort dropdowns into visually distinct controls, each with its own background and border
- Previously they shared a single container, making them look like one combined control

## Test plan
- [x] Verified visually via CDP screenshot that the two dropdowns appear as separate bordered controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)