### PR TITLE
Render Agent tool invocations as TaskCards with grouped child tool calls

### DIFF
--- a/packages/core/src/providers/claude-code.provider.ts
+++ b/packages/core/src/providers/claude-code.provider.ts
@@ -581,11 +581,16 @@ export class ClaudeCodeProvider implements AgentProvider {
               if (toolId) {
                 this.pendingToolIds.set(blockIndex, toolId);
               }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const parentId = (msg as any).parent_tool_use_id as
+                | string
+                | undefined;
               yield {
                 type: "tool_use",
                 toolName: block.name,
                 input: block.input ?? {},
                 toolCallId: toolId,
+                ...(parentId && { parentToolUseId: parentId }),
               };
             }
           }

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -67,6 +67,7 @@ export type AgentMessage =
       toolName: string;
       input: Record<string, unknown>;
       toolCallId: string;
+      parentToolUseId?: string;
     }
   | { type: "tool_result"; toolCallId: string; output: string }
   | { type: "todo_update"; todos: TodoItem[] }

--- a/packages/desktop/src/renderer/hooks/useChat.ts
+++ b/packages/desktop/src/renderer/hooks/useChat.ts
@@ -430,7 +430,7 @@ export function useChat(
             status: "running",
           };
 
-          if (msg.toolName === "Task") {
+          if (msg.toolName === "Task" || msg.toolName === "Agent") {
             // Task tool call - create TaskInfo and track it
             const taskInfo: TaskInfo = {
               taskId: msg.toolCallId,
@@ -458,11 +458,12 @@ export function useChat(
                 toolCalls: [toolCall],
               },
             ]);
-          } else if (state.activeTaskId) {
-            // Child tool call - associate with active task
+          } else if (msg.parentToolUseId || state.activeTaskId) {
+            // Child tool call - associate with parent task by direct reference or active task
+            const parentTaskId = msg.parentToolUseId ?? state.activeTaskId;
             apply((prev) =>
               prev.map((m) => {
-                if (m.taskInfo?.taskId === state.activeTaskId) {
+                if (m.taskInfo?.taskId === parentTaskId && m.taskInfo) {
                   return {
                     ...m,
                     taskInfo: {
@@ -471,9 +472,9 @@ export function useChat(
                         ...m.taskInfo.childToolCalls,
                         msg.toolCallId,
                       ],
-                    },
+                    } as ChatMessage["taskInfo"],
                     toolCalls: [...(m.toolCalls ?? []), toolCall],
-                  };
+                  } as ChatMessage;
                 }
                 return m;
               }),


### PR DESCRIPTION
## Summary

- When Claude Code spawns a subagent via the **Agent** tool, the invocation now renders as a collapsible **TaskCard** (same as the Task tool) instead of a flat ToolCallCard
- Child tool calls are grouped inside the TaskCard using `parentToolUseId` (direct SDK reference) as the primary key, with `activeTaskId` as a fallback — ensuring correct grouping regardless of stream event ordering
- Added `parentToolUseId?: string` to the `tool_use` AgentMessage type and forwarded `parent_tool_use_id` from raw SDK events in the Claude Code provider

## Test plan

- [x] Visually verified via CDP: Agent tool invocation renders as `🔍 Explore` TaskCard with description, elapsed time, and collapsible "Task details"
- [x] TypeScript: no new errors introduced (two pre-existing errors in ComponentGallery unrelated to this change)
- [x] Existing Task tool behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)