### PR TITLE
Fix tools badge count and popover footer for MCP-only sessions

### DIFF
--- a/packages/ui/src/__tests__/ChatInfoBar.test.tsx
+++ b/packages/ui/src/__tests__/ChatInfoBar.test.tsx
@@ -59,6 +59,6 @@ describe("ChatInfoBar", () => {
     );
 
     expect(screen.getByTitle("View available tools")).toBeInTheDocument();
-    expect(screen.getByText("0 tools")).toBeInTheDocument();
+    expect(screen.getByText("1 tools")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/ChatInfoBar.tsx
+++ b/packages/ui/src/components/ChatInfoBar.tsx
@@ -84,7 +84,13 @@ export function ChatInfoBar({
         <div className="flex items-center gap-1.5 flex-shrink-0">
           {hasToolsBadge && (
             <ToolsBadge
-              toolCount={sessionTools?.length ?? 0}
+              toolCount={
+                (sessionTools?.length ?? 0) +
+                (mcpServers?.reduce(
+                  (sum, s) => sum + (s.tools?.length ?? 0),
+                  0,
+                ) ?? 0)
+              }
               sessionTools={sessionTools ?? []}
               mcpServers={mcpServers}
               onToggleServer={onToggleMcpServer}

--- a/packages/ui/src/components/ToolsPopover.tsx
+++ b/packages/ui/src/components/ToolsPopover.tsx
@@ -165,7 +165,13 @@ export function ToolsPopover({
       <PanelCard
         title="Available Tools"
         headerAction={closeButton}
-        footer={`${mcpToolCount} MCP · ${builtInCount} built-in · ${sessionTools.length} total`}
+        footer={[
+          `${mcpToolCount} MCP`,
+          builtInCount > 0 ? `${builtInCount} built-in` : null,
+          sessionTools.length > 0 ? `${sessionTools.length} total` : null,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
       >
         {builtInCount > 0 && (
           <div className="flex items-center justify-between px-4 py-2.5 border-b border-[var(--border)]">


### PR DESCRIPTION
## Summary

- **Badge count was always 0** when using Codex (no active session tools): `toolCount` only counted `sessionTools`, ignoring MCP server tool counts. Now sums both.
- **Popover footer showed misleading zeros** (`60 MCP · 0 built-in · 0 total`): built-in and total counts are now hidden when zero, so the footer shows just `60 MCP` in that case.

## Test plan
- [x] `ChatInfoBar` test updated to assert correct count (1 tool from fixture MCP server)
- [x] All 56 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)