### PR TITLE
Fix Codex CLI not found in packaged app

### DIFF
--- a/packages/core/src/providers/codex.provider.ts
+++ b/packages/core/src/providers/codex.provider.ts
@@ -70,18 +70,46 @@ function findCodexBinary(): string {
   const binaryName = process.platform === "win32" ? "codex.exe" : "codex";
   const binaryRelPath = path.join("vendor", targetTriple, "codex", binaryName);
 
-  // Walk up from multiple starting points looking for the codex binary
+  // The native binary lives in the platform-specific optional package,
+  // e.g. @openai/codex-darwin-arm64, not in @openai/codex itself.
+  const platformPackageMap: Record<string, string> = {
+    "x86_64-unknown-linux-musl": "@openai/codex-linux-x64",
+    "aarch64-unknown-linux-musl": "@openai/codex-linux-arm64",
+    "x86_64-apple-darwin": "@openai/codex-darwin-x64",
+    "aarch64-apple-darwin": "@openai/codex-darwin-arm64",
+    "x86_64-pc-windows-msvc": "@openai/codex-win32-x64",
+    "aarch64-pc-windows-msvc": "@openai/codex-win32-arm64",
+  };
+  const platformPackage = platformPackageMap[targetTriple];
+
+  // Walk up from multiple starting points looking for the codex binary.
+  // app.asar.unpacked must come before __dirname: in a packaged app __dirname
+  // is inside app.asar, and Electron's fs intercept makes existsSync return
+  // true for asar-relative paths, but spawn() goes to the OS and fails with
+  // ENOTDIR because app.asar is a file, not a directory.
+  const resourcesPath: string | undefined = (process as any).resourcesPath;
   const startDirs = [
+    ...(resourcesPath
+      ? [path.join(resourcesPath, "app.asar.unpacked"), resourcesPath]
+      : []),
     __dirname,
     process.cwd(),
-    ...(process.versions?.electron
-      ? [(process as any).resourcesPath ?? ""]
-      : []),
   ].filter(Boolean);
 
   for (const startDir of startDirs) {
     let dir = startDir;
     for (let i = 0; i < 10; i++) {
+      // Check platform-specific package (primary location)
+      if (platformPackage) {
+        const platformCandidate = path.join(
+          dir,
+          "node_modules",
+          platformPackage,
+          binaryRelPath,
+        );
+        if (fs.existsSync(platformCandidate)) return platformCandidate;
+      }
+
       // Check pnpm hoisted layout: node_modules/.pnpm/@openai+codex@*-<platform>-<arch>/...
       const pnpmDir = path.join(dir, "node_modules", ".pnpm");
       try {
@@ -100,6 +128,21 @@ function findCodexBinary(): string {
               binaryRelPath,
             );
             if (fs.existsSync(candidate)) return candidate;
+
+            // Also check platform package inside pnpm entry
+            if (platformPackage) {
+              const [, pkgName] = platformPackage.split("/");
+              const pnpmPlatformCandidate = path.join(
+                pnpmDir,
+                entry,
+                "node_modules",
+                "@openai",
+                pkgName,
+                binaryRelPath,
+              );
+              if (fs.existsSync(pnpmPlatformCandidate))
+                return pnpmPlatformCandidate;
+            }
           }
         }
       } catch {

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -15,6 +15,10 @@ files:
 asarUnpack:
   - "node_modules/@anthropic-ai/claude-agent-sdk/**"
   - "node_modules/@img/**"
+  - "node_modules/@openai/codex/**"
+  - "node_modules/@openai/codex-sdk/**"
+  - "node_modules/@openai/codex-darwin-arm64/**"
+  - "node_modules/@openai/codex-darwin-x64/**"
 
 mac:
   category: public.app-category.developer-tools

--- a/packages/desktop/src/main/integrations/codex.ipc.ts
+++ b/packages/desktop/src/main/integrations/codex.ipc.ts
@@ -63,15 +63,45 @@ function findCodexBinary(): string {
   const binaryName = process.platform === "win32" ? "codex.exe" : "codex";
   const binaryRelPath = path.join("vendor", targetTriple, "codex", binaryName);
 
+  // The native binary lives in the platform-specific optional package,
+  // e.g. @openai/codex-darwin-arm64, not in @openai/codex itself.
+  const platformPackageMap: Record<string, string> = {
+    "x86_64-unknown-linux-musl": "@openai/codex-linux-x64",
+    "aarch64-unknown-linux-musl": "@openai/codex-linux-arm64",
+    "x86_64-apple-darwin": "@openai/codex-darwin-x64",
+    "aarch64-apple-darwin": "@openai/codex-darwin-arm64",
+    "x86_64-pc-windows-msvc": "@openai/codex-win32-x64",
+    "aarch64-pc-windows-msvc": "@openai/codex-win32-arm64",
+  };
+  const platformPackage = platformPackageMap[targetTriple];
+
+  // app.asar.unpacked must come before __dirname: in a packaged app __dirname
+  // is inside app.asar, and Electron's fs intercept makes existsSync return
+  // true for asar-relative paths, but spawn() goes to the OS and fails with
+  // ENOTDIR because app.asar is a file, not a directory.
+  const resourcesPath: string | undefined = (process as any).resourcesPath;
   const startDirs = [
+    ...(resourcesPath
+      ? [path.join(resourcesPath, "app.asar.unpacked"), resourcesPath]
+      : []),
     __dirname,
     process.cwd(),
-    ...((process as any).resourcesPath ? [(process as any).resourcesPath] : []),
   ].filter(Boolean);
 
   for (const startDir of startDirs) {
     let dir = startDir;
     for (let i = 0; i < 10; i++) {
+      // Check platform-specific package (primary location)
+      if (platformPackage) {
+        const platformCandidate = path.join(
+          dir,
+          "node_modules",
+          platformPackage,
+          binaryRelPath,
+        );
+        if (fs.existsSync(platformCandidate)) return platformCandidate;
+      }
+
       // pnpm hoisted layout
       const pnpmDir = path.join(dir, "node_modules", ".pnpm");
       try {
@@ -90,6 +120,20 @@ function findCodexBinary(): string {
               binaryRelPath,
             );
             if (fs.existsSync(candidate)) return candidate;
+
+            if (platformPackage) {
+              const [, pkgName] = platformPackage.split("/");
+              const pnpmPlatformCandidate = path.join(
+                pnpmDir,
+                entry,
+                "node_modules",
+                "@openai",
+                pkgName,
+                binaryRelPath,
+              );
+              if (fs.existsSync(pnpmPlatformCandidate))
+                return pnpmPlatformCandidate;
+            }
           }
         }
       } catch {


### PR DESCRIPTION
## Summary
- The Codex binary lives in the platform-specific optional package (`@openai/codex-darwin-arm64`), not in `@openai/codex` itself — updated `findCodexBinary()` in both `codex.provider.ts` and `codex.ipc.ts` to check there first
- Added `@openai/codex`, `@openai/codex-sdk`, `@openai/codex-darwin-arm64`, and `@openai/codex-darwin-x64` to `asarUnpack` so the native binary is accessible at runtime
- Reordered search paths to check `app.asar.unpacked` before `__dirname` — Electron's fs intercept causes `existsSync` to return true for asar-relative paths, but `spawn()` hits the OS and fails with `ENOTDIR`

## Test plan
- [ ] Build packaged app with `pnpm build:mac:dir`
- [ ] Open packaged Stratos.app and navigate to Codex settings
- [ ] Confirm "Codex CLI not found" error is gone
- [ ] Confirm Codex connects and responds to messages

Fixes codex in v0.0.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)