### PR TITLE
Fix MarkdownPreview invisible text in light mode

### DIFF
--- a/packages/ui/src/components/preview/MarkdownPreview.tsx
+++ b/packages/ui/src/components/preview/MarkdownPreview.tsx
@@ -10,27 +10,27 @@ interface Props {
 export function MarkdownPreview({ content }: Props): React.ReactElement {
   return (
     <div className="flex-1 overflow-y-auto p-6">
-      <div className="max-w-none text-gray-200 text-sm leading-relaxed">
+      <div className="max-w-none text-[var(--text-primary)] text-sm leading-relaxed">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
             h1: ({ children }) => (
-              <h1 className="text-2xl font-bold text-gray-100 mt-6 mb-3 first:mt-0">
+              <h1 className="text-2xl font-bold text-[var(--text-primary)] mt-6 mb-3 first:mt-0">
                 {children}
               </h1>
             ),
             h2: ({ children }) => (
-              <h2 className="text-xl font-semibold text-gray-100 mt-5 mb-2">
+              <h2 className="text-xl font-semibold text-[var(--text-primary)] mt-5 mb-2">
                 {children}
               </h2>
             ),
             h3: ({ children }) => (
-              <h3 className="text-lg font-semibold text-gray-200 mt-4 mb-2">
+              <h3 className="text-lg font-semibold text-[var(--text-primary)] mt-4 mb-2">
                 {children}
               </h3>
             ),
             h4: ({ children }) => (
-              <h4 className="text-base font-semibold text-gray-200 mt-3 mb-1">
+              <h4 className="text-base font-semibold text-[var(--text-primary)] mt-3 mb-1">
                 {children}
               </h4>
             ),
@@ -41,9 +41,11 @@ export function MarkdownPreview({ content }: Props): React.ReactElement {
             ol: ({ children }) => (
               <ol className="list-decimal pl-5 mb-3 space-y-1">{children}</ol>
             ),
-            li: ({ children }) => <li className="text-gray-300">{children}</li>,
+            li: ({ children }) => (
+              <li className="text-[var(--text-secondary)]">{children}</li>
+            ),
             blockquote: ({ children }) => (
-              <blockquote className="border-l-2 border-gray-600 pl-4 my-3 text-gray-400 italic">
+              <blockquote className="border-l-2 border-[var(--border-mid)] pl-4 my-3 text-[var(--text-muted)] italic">
                 {children}
               </blockquote>
             ),
@@ -55,16 +57,16 @@ export function MarkdownPreview({ content }: Props): React.ReactElement {
               </div>
             ),
             th: ({ children }) => (
-              <th className="border border-gray-700 px-3 py-1.5 bg-[var(--bg-surface)] text-left font-semibold text-gray-200">
+              <th className="border border-[var(--border-mid)] px-3 py-1.5 bg-[var(--bg-surface)] text-left font-semibold text-[var(--text-primary)]">
                 {children}
               </th>
             ),
             td: ({ children }) => (
-              <td className="border border-gray-700 px-3 py-1.5 text-gray-300">
+              <td className="border border-[var(--border-mid)] px-3 py-1.5 text-[var(--text-secondary)]">
                 {children}
               </td>
             ),
-            hr: () => <hr className="border-gray-700 my-4" />,
+            hr: () => <hr className="border-[var(--border-mid)] my-4" />,
             a: ({ href, children }) => (
               <a
                 href={href}
@@ -76,7 +78,7 @@ export function MarkdownPreview({ content }: Props): React.ReactElement {
               </a>
             ),
             strong: ({ children }) => (
-              <strong className="font-semibold text-gray-100">
+              <strong className="font-semibold text-[var(--text-primary)]">
                 {children}
               </strong>
             ),
@@ -103,7 +105,7 @@ export function MarkdownPreview({ content }: Props): React.ReactElement {
                 </SyntaxHighlighter>
               ) : (
                 <code
-                  className={`${className ?? ""} bg-gray-800 px-1.5 py-0.5 rounded text-xs`}
+                  className={`${className ?? ""} bg-[var(--bg-surface)] px-1.5 py-0.5 rounded text-xs`}
                   {...props}
                 >
                   {children}


### PR DESCRIPTION
## Summary
- Replace hardcoded `text-gray-*` Tailwind classes in `MarkdownPreview` with theme-aware `var(--text-*)` CSS variables
- Also fixes hardcoded `border-gray-*` and `bg-gray-800` to use `var(--border-mid)` and `var(--bg-surface)`
- Headings, paragraphs, list items, blockquotes, tables, and inline code all now respect light/dark theme

## Test plan
- [ ] Open a markdown file in the file viewer in light mode — text should be readable
- [ ] Switch to dark mode — text should still render correctly
- [ ] Verify tables, blockquotes, code blocks render properly in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)