### PR TITLE
fix: scroll to bottom when opening an existing thread

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -893,6 +893,7 @@ function AppInner(): React.ReactElement {
 
                   {/* Chat messages */}
                   <ChatView
+                    key={activeThreadId ?? "new"}
                     provider={
                       ((activeThread?.provider as "claude-code" | "codex") ??
                         pendingProvider) as "claude-code" | "codex"


### PR DESCRIPTION
## What does this PR do?

When opening an existing thread, the chat view now scrolls to the latest message instead of starting at the top.

The root cause: `ChatView` was not re-mounting on thread switch, so `isNearBottomRef` (which starts as `true`) could be stale from a previous thread where the user had scrolled up. Adding `key={activeThreadId}` causes React to remount `ChatView` on each thread switch, resetting scroll state and triggering the auto-scroll effect as messages load.

## How was this tested?

- Opened existing threads with message history — confirmed view now loads at the latest message
- Verified auto-scroll during active streaming still works (new messages scroll into view)
- Verified manual scroll-up is preserved within a session

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Layer boundaries respected (see `CLAUDE.md`)
- [ ] UI changes visually verified