### PR TITLE
feat: add Ollama integration for local models via Opencode provider

### DIFF
--- a/docs/ollama-integration-plan.md
+++ b/docs/ollama-integration-plan.md
@@ -1,0 +1,547 @@
+# Ollama Integration Plan (via Opencode Provider)
+
+## Summary
+
+Enable Stratos to use local Ollama models (e.g. `gemma4:26b`) through the existing Opencode provider. Ollama runs at `localhost:11434` and exposes an OpenAI-compatible API. Opencode supports custom providers via `OPENCODE_CONFIG_CONTENT` using the `@ai-sdk/openai-compatible` SDK adapter.
+
+## Proof of Concept (verified)
+
+The following command successfully sends a prompt to Ollama through opencode, with tool calling:
+
+```bash
+OPENCODE_CONFIG_CONTENT='{
+  "provider": {
+    "ollama": {
+      "id": "ollama",
+      "name": "Ollama",
+      "npm": "@ai-sdk/openai-compatible",
+      "api": "http://localhost:11434/v1",
+      "options": { "apiKey": "ollama" },
+      "models": {
+        "gemma4:26b": {
+          "id": "gemma4:26b",
+          "name": "Gemma 4 26B",
+          "tool_call": true,
+          "temperature": true,
+          "limit": { "context": 131072, "output": 8192 }
+        }
+      }
+    }
+  }
+}' opencode run -m "ollama/gemma4:26b" "Read package.json and tell me the project name"
+```
+
+Result: opencode successfully calls its `read` tool and returns the answer. Server mode (`opencode serve`) also works and exposes the ollama provider at `/provider` with `status: "active"`.
+
+## Current Architecture
+
+The opencode provider config flow in Stratos today:
+
+```
+app-settings.json                     buildOpencodeEnv()                   opencode server
+  opencodeProviderKeys: {     --->    OPENCODE_CONFIG_CONTENT:    --->     Recognizes provider,
+    "anthropic": {                    {"provider": {                       fetches models,
+      apiKey: "sk-ant-..."            "anthropic": {                       accepts messages
+    }                                   "options": { "apiKey": "..." }
+  }                                   }}}
+```
+
+**Problem:** `buildOpencodeEnv()` only passes `{ options: { apiKey, baseURL? } }` per provider. For Ollama, we need the full provider definition including `npm`, `api`, and `models` fields because "ollama" is not a built-in opencode provider.
+
+## Implementation Plan
+
+### Phase 1: Core — Extend config to support full provider definitions
+
+**File: `packages/core/src/providers/types.ts`**
+
+Add an `OpencodeCustomProvider` type alongside the existing simple key format:
+
+```typescript
+export interface OpencodeCustomProvider {
+  id: string;
+  name: string;
+  npm: string; // e.g. "@ai-sdk/openai-compatible"
+  api: string; // e.g. "http://localhost:11434/v1"
+  apiKey?: string; // dummy key for Ollama ("ollama"), real key for others
+  models: Record<
+    string,
+    {
+      id: string;
+      name: string;
+      tool_call?: boolean;
+      temperature?: boolean;
+      reasoning?: boolean;
+      attachment?: boolean; // vision/image input support
+      limit?: { context?: number; output?: number };
+    }
+  >;
+}
+```
+
+Update `ProviderConfig.opencodeConfig`:
+
+```typescript
+opencodeConfig?: {
+  providers?: Record<string, { apiKey: string; baseURL?: string }>;
+  customProviders?: Record<string, OpencodeCustomProvider>;  // NEW
+  port?: number;
+  binaryPath?: string;
+};
+```
+
+**File: `packages/core/src/providers/opencode.provider.ts`**
+
+Update `buildOpencodeEnv()` to merge custom provider definitions into `OPENCODE_CONFIG_CONTENT`:
+
+```typescript
+function buildOpencodeEnv(config: ProviderConfig): NodeJS.ProcessEnv {
+  const providers = config.opencodeConfig?.providers ?? {};
+  const customProviders = config.opencodeConfig?.customProviders ?? {};
+
+  const providerConfig: Record<string, unknown> = {};
+
+  // Standard providers: just inject apiKey + baseURL
+  for (const [id, { apiKey, baseURL }] of Object.entries(providers)) {
+    if (!apiKey) continue;
+    providerConfig[id] = {
+      options: { apiKey, ...(baseURL ? { baseURL } : {}) },
+    };
+  }
+
+  // Custom providers: inject full definition (npm, api, models, etc.)
+  for (const [id, def] of Object.entries(customProviders)) {
+    providerConfig[id] = {
+      id: def.id,
+      name: def.name,
+      npm: def.npm,
+      api: def.api,
+      options: { apiKey: def.apiKey ?? "none" },
+      models: def.models,
+    };
+  }
+
+  return {
+    ...process.env,
+    ...(Object.keys(providerConfig).length > 0
+      ? {
+          OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: providerConfig }),
+        }
+      : {}),
+  };
+}
+```
+
+### Phase 2: Settings Store — Persist Ollama configuration
+
+**File: `packages/desktop/src/main/settings/settings.store.ts`**
+
+Add new types and CRUD helpers:
+
+```typescript
+export interface OllamaModelInfo {
+  name: string;
+  size: number;               // bytes on disk
+  parameterSize: string;      // e.g. "25.8B"
+  family: string;             // e.g. "gemma4"
+  quantization: string;       // e.g. "Q4_K_M"
+  capabilities: {
+    vision: boolean;          // from /api/show capabilities.includes("vision")
+    tools: boolean;           // from /api/show capabilities.includes("tools")
+    thinking: boolean;        // from /api/show capabilities.includes("thinking")
+  };
+  contextLength: number;      // from /api/show model_info.{family}.context_length
+}
+
+export interface OllamaConfig {
+  baseURL: string;                          // default: "http://localhost:11434"
+  models: Record<string, OllamaModelInfo>;  // keyed by model name (e.g. "gemma4:26b")
+}
+
+// In AppSettings:
+ollamaConfig?: OllamaConfig;
+
+// CRUD helpers:
+export function getOllamaConfig(): OllamaConfig | undefined;
+export function setOllamaConfig(config: OllamaConfig): void;
+export function clearOllamaConfig(): void;
+```
+
+### Phase 3: Agent Manager — Wire Ollama config into opencode init
+
+**File: `packages/desktop/src/main/agent-manager.ts`**
+
+When initializing the opencode provider, build the `customProviders` record from `ollamaConfig`, mapping the rich model metadata (capabilities, context window) into the opencode model definition:
+
+```typescript
+// In the opencode provider initialization block:
+const ollamaConfig = getOllamaConfig();
+const customProviders: Record<string, OpencodeCustomProvider> = {};
+
+if (ollamaConfig && Object.keys(ollamaConfig.models).length > 0) {
+  customProviders["ollama"] = {
+    id: "ollama",
+    name: "Ollama",
+    npm: "@ai-sdk/openai-compatible",
+    api: `${ollamaConfig.baseURL}/v1`,
+    apiKey: "ollama",
+    models: Object.fromEntries(
+      Object.entries(ollamaConfig.models).map(([id, m]) => [
+        id,
+        {
+          id,
+          name: `${m.name} (${m.parameterSize})`,
+          tool_call: m.capabilities.tools,       // from /api/show
+          temperature: true,
+          reasoning: m.capabilities.thinking,     // from /api/show
+          attachment: m.capabilities.vision,       // from /api/show — enables image input
+          limit: {
+            context: m.contextLength,             // from /api/show model_info
+            output: 8192,
+          },
+        },
+      ]),
+    ),
+  };
+}
+
+await provider.initialize({
+  opencodeConfig: {
+    providers: getOpencodeProviderKeys(),
+    customProviders,
+  },
+  ...
+});
+```
+
+Add IPC handlers for Ollama config + model discovery (see "Discovery flow" section below for full implementation of `OLLAMA_DISCOVER_MODELS`):
+
+```typescript
+ipcMain.handle(IPC_CHANNELS.OLLAMA_GET_CONFIG, async () => getOllamaConfig());
+ipcMain.handle(IPC_CHANNELS.OLLAMA_SET_CONFIG, async (_event, config) => {
+  setOllamaConfig(config);
+  OpencodeProvider.restartServer();
+  this.modelsCache.delete("opencode");
+});
+ipcMain.handle(IPC_CHANNELS.OLLAMA_DISCOVER_MODELS, async (_event, baseURL) => {
+  // Two-step discovery: /api/tags + /api/show per model
+  // See "Discovery flow" section for full implementation
+});
+```
+
+### Phase 4: IPC Channels & Preload
+
+**File: `packages/desktop/src/common/ipc-channels.ts`**
+
+```typescript
+OLLAMA_GET_CONFIG: "integration:ollama:get-config",
+OLLAMA_SET_CONFIG: "integration:ollama:set-config",
+OLLAMA_DISCOVER_MODELS: "integration:ollama:discover-models",
+```
+
+**File: `packages/desktop/src/preload/index.ts`**
+
+```typescript
+ollamaGetConfig: () => ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_GET_CONFIG),
+ollamaSetConfig: (config) => ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_SET_CONFIG, config),
+ollamaDiscoverModels: (baseURL) => ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_DISCOVER_MODELS, baseURL),
+```
+
+### Phase 5: UI — Ollama Settings
+
+**File: `packages/desktop/src/renderer/components/OllamaSettingsDialog.tsx`** (new)
+
+A dialog that:
+
+1. Shows a "Base URL" input (default: `http://localhost:11434`)
+2. Has a "Discover Models" button that fetches from Ollama's `/api/tags`
+3. Displays discovered models with checkboxes to enable/disable
+4. Shows model metadata (size, parameter count, family)
+5. Saves configuration to `app-settings.json`
+6. Adds "ollama" to the model allowlist automatically
+
+**File: `packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx`**
+
+Add an "Ollama (Local)" button/section that opens the OllamaSettingsDialog, or integrate it as a special provider in the existing dialog.
+
+### Phase 6: Model Allowlist
+
+Update `DEFAULT_OPENCODE_MODEL_ALLOWLIST` to include "ollama" when ollamaConfig is set, or auto-add "ollama" to the allowlist when the user configures it.
+
+## File Change Summary
+
+| File                                                                  | Change                                                       |
+| --------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `packages/core/src/providers/types.ts`                                | Add `OpencodeCustomProvider` type, extend `opencodeConfig`   |
+| `packages/core/src/providers/opencode.provider.ts`                    | Extend `buildOpencodeEnv()` to merge custom providers        |
+| `packages/desktop/src/main/settings/settings.store.ts`                | Add `OllamaConfig` type + CRUD helpers                       |
+| `packages/desktop/src/main/agent-manager.ts`                          | Build `customProviders` from ollama config, add IPC handlers |
+| `packages/desktop/src/common/ipc-channels.ts`                         | Add 3 Ollama IPC channels                                    |
+| `packages/desktop/src/preload/index.ts`                               | Expose 3 Ollama APIs to renderer                             |
+| `packages/desktop/src/renderer/components/OllamaSettingsDialog.tsx`   | New: Ollama config UI with model discovery                   |
+| `packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx` | Add Ollama entry point                                       |
+| `packages/desktop/src/renderer/App.tsx`                               | Wire OllamaSettingsDialog                                    |
+
+## Testing Plan
+
+### 1. Prerequisites
+
+```bash
+# Verify Ollama is running
+curl http://localhost:11434/api/tags
+# Should list gemma4:26b
+
+# Verify opencode is installed
+opencode --version
+# Should be >= 1.3.17
+```
+
+### 2. Manual E2E Test
+
+1. Open Stratos, go to Opencode Settings
+2. Click "Ollama (Local)" to open Ollama configuration
+3. Click "Discover Models" — should show `gemma4:26b`
+4. Enable the model and save
+5. Create a new thread, select Opencode provider
+6. In the model picker, `ollama/gemma4:26b` should appear
+7. Send a message — should get a streaming response from local Ollama
+8. Test tool use: "Read the file package.json" — should invoke opencode's `read` tool
+9. Test session resume: send a follow-up message in the same thread
+
+### 3. Unit Tests
+
+- `buildOpencodeEnv()` correctly merges custom providers into `OPENCODE_CONFIG_CONTENT`
+- `parseOpencodeModels()` correctly parses the ollama provider from `/provider` response
+- Settings store CRUD for `ollamaConfig`
+
+### 4. Edge Cases
+
+- Ollama not running: model discovery should show a clear error
+- Ollama model pulled/removed between discovery and use: opencode returns an error that Stratos surfaces
+- Multiple Ollama models: each appears as `ollama/<model-name>` in the picker
+- Ollama URL changed: restart opencode server, re-discover models
+
+## Alternatives Considered
+
+### A. Direct Ollama provider (new provider type)
+
+Create a `packages/core/src/providers/ollama.provider.ts` that talks directly to Ollama's API using the `openai` npm package. This would require implementing the full agentic loop (tool calling, multi-turn, file I/O) from scratch. **Rejected** because opencode already has a mature tool execution engine.
+
+### B. Modify opencode's models.json cache
+
+Directly edit `~/.cache/opencode/models.json` to add an "ollama" provider. **Rejected** because it's fragile (overwritten on opencode updates) and not user-configurable.
+
+### C. Use lmstudio provider with custom baseURL
+
+Point the existing `lmstudio` provider at Ollama's port. **Rejected** because model IDs would be wrong (lmstudio has hardcoded model list) and it's semantically misleading.
+
+## Ollama Model Metadata API (verified)
+
+Model discovery requires two API calls per model:
+
+### Step 1: `GET /api/tags` — list all local models
+
+Returns basic info only (name, size, family). Does **not** include capabilities or context window.
+
+```json
+{
+  "models": [
+    {
+      "name": "gemma4:26b",
+      "model": "gemma4:26b",
+      "size": 17987581215,
+      "details": {
+        "family": "gemma4",
+        "families": ["gemma4"],
+        "parameter_size": "25.8B",
+        "quantization_level": "Q4_K_M"
+      }
+    }
+  ]
+}
+```
+
+### Step 2: `POST /api/show` — get capabilities and context window per model
+
+Request: `{ "model": "gemma4:26b" }`
+
+Key fields in the response:
+
+| Field                         | Example                                         | Use                                                      |
+| ----------------------------- | ----------------------------------------------- | -------------------------------------------------------- |
+| `capabilities`                | `["completion", "vision", "tools", "thinking"]` | Detect vision, tool calling, reasoning support           |
+| `model_info.*.context_length` | `262144`                                        | Actual context window (key is `{family}.context_length`) |
+| `details.parameter_size`      | `"25.8B"`                                       | Display in model picker                                  |
+| `details.family`              | `"gemma4"`                                      | Used to find the context_length key in model_info        |
+
+### Capability mapping to opencode model definition
+
+```typescript
+// Ollama capabilities → opencode model fields
+const capabilities: string[] = showResponse.capabilities ?? [];
+
+const modelDef = {
+  id: model.name,
+  name: formatDisplayName(model.name, details.parameter_size),
+  tool_call: capabilities.includes("tools"), // default true if missing
+  temperature: true, // always supported
+  reasoning: capabilities.includes("thinking"),
+  attachment: capabilities.includes("vision"), // enables image input
+  limit: {
+    context:
+      extractContextLength(showResponse.model_info, details.family) ?? 131072,
+    output: 8192, // Ollama doesn't report max output tokens; 8192 is a safe default
+  },
+};
+```
+
+### Context length extraction
+
+The context length is stored in `model_info` under a key like `{family}.context_length`:
+
+```typescript
+function extractContextLength(
+  modelInfo: Record<string, unknown>,
+  family: string,
+): number | undefined {
+  // Try family-specific key first (e.g. "gemma4.context_length")
+  const familyKey = `${family}.context_length`;
+  if (typeof modelInfo[familyKey] === "number") {
+    return modelInfo[familyKey] as number;
+  }
+  // Fallback: search for any key ending in ".context_length"
+  for (const [key, value] of Object.entries(modelInfo)) {
+    if (key.endsWith(".context_length") && typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+```
+
+### Discovery flow (updated)
+
+The `OLLAMA_DISCOVER_MODELS` IPC handler performs both calls:
+
+```typescript
+ipcMain.handle(
+  IPC_CHANNELS.OLLAMA_DISCOVER_MODELS,
+  async (_event, baseURL: string) => {
+    // 1. List all models
+    const tagsResp = await fetch(`${baseURL}/api/tags`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!tagsResp.ok) throw new Error(`Ollama not reachable at ${baseURL}`);
+    const { models } = await tagsResp.json();
+
+    // 2. Enrich each model with capabilities + context window
+    const enriched = await Promise.all(
+      models.map(async (m) => {
+        try {
+          const showResp = await fetch(`${baseURL}/api/show`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model: m.name }),
+            signal: AbortSignal.timeout(5000),
+          });
+          const show = await showResp.json();
+          const capabilities: string[] = show.capabilities ?? [];
+          const family = m.details?.family ?? "";
+          const contextLength = extractContextLength(
+            show.model_info ?? {},
+            family,
+          );
+
+          return {
+            name: m.name,
+            size: m.size,
+            parameterSize: m.details?.parameter_size ?? "unknown",
+            family,
+            quantization: m.details?.quantization_level ?? "unknown",
+            capabilities: {
+              vision: capabilities.includes("vision"),
+              tools: capabilities.includes("tools"),
+              thinking: capabilities.includes("thinking"),
+            },
+            contextLength: contextLength ?? 131072,
+          };
+        } catch {
+          // If /api/show fails for a model, return with defaults
+          return {
+            name: m.name,
+            size: m.size,
+            parameterSize: m.details?.parameter_size ?? "unknown",
+            family: m.details?.family ?? "",
+            quantization: m.details?.quantization_level ?? "unknown",
+            capabilities: { vision: false, tools: true, thinking: false },
+            contextLength: 131072,
+          };
+        }
+      }),
+    );
+
+    return enriched;
+  },
+);
+```
+
+### Updated OllamaConfig type
+
+```typescript
+export interface OllamaModelInfo {
+  name: string;
+  size: number;
+  parameterSize: string;
+  family: string;
+  quantization: string;
+  capabilities: {
+    vision: boolean;
+    tools: boolean;
+    thinking: boolean;
+  };
+  contextLength: number;
+}
+
+export interface OllamaConfig {
+  baseURL: string; // default: "http://localhost:11434"
+  models: Record<string, OllamaModelInfo>; // keyed by model name (e.g. "gemma4:26b")
+}
+```
+
+### Updated agent-manager model mapping
+
+```typescript
+if (ollamaConfig && Object.keys(ollamaConfig.models).length > 0) {
+  customProviders["ollama"] = {
+    id: "ollama",
+    name: "Ollama",
+    npm: "@ai-sdk/openai-compatible",
+    api: `${ollamaConfig.baseURL}/v1`,
+    apiKey: "ollama",
+    models: Object.fromEntries(
+      Object.entries(ollamaConfig.models).map(([id, m]) => [
+        id,
+        {
+          id,
+          name: `${m.name} (${m.parameterSize})`,
+          tool_call: m.capabilities.tools,
+          temperature: true,
+          reasoning: m.capabilities.thinking,
+          attachment: m.capabilities.vision,
+          limit: {
+            context: m.contextLength,
+            output: 8192,
+          },
+        },
+      ]),
+    ),
+  };
+}
+```
+
+## Resolved Decisions
+
+1. **Tool calling**: Default to `true` for all models. Ollama's `/api/show` provides explicit `capabilities` array — use `capabilities.includes("tools")` when available, fall back to `true`.
+
+2. **Vision/image support**: Detected from `capabilities.includes("vision")` in `/api/show` response. Maps to `attachment: true` in the opencode model definition. For gemma4, this is `true`. No deferral needed.
+
+3. **Context window**: Extracted from `model_info.{family}.context_length` in `/api/show` response. For gemma4:26b this is `262144`. Falls back to `131072` if unavailable.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
   TodoItem,
   McpServerInfo,
   McpElicitationRequest,
+  OpencodeCustomProvider,
 } from "./providers/types";
 export { READ_ONLY_TOOLS } from "./providers/types";
 export { ClaudeCodeProvider } from "./providers/claude-code.provider";

--- a/packages/core/src/providers/opencode.provider.ts
+++ b/packages/core/src/providers/opencode.provider.ts
@@ -146,30 +146,40 @@ function resolveOpencodeBinary(binaryPath?: string): string {
 
 function buildOpencodeEnv(config: ProviderConfig): NodeJS.ProcessEnv {
   const providers = config.opencodeConfig?.providers ?? {};
-  const providerEntries = Object.entries(providers).filter(([, v]) => v.apiKey);
+  const customProviders = config.opencodeConfig?.customProviders ?? {};
 
-  const opencodeConfigContent =
-    providerEntries.length > 0
-      ? {
-          provider: Object.fromEntries(
-            providerEntries.map(([id, { apiKey, baseURL }]) => [
-              id,
-              {
-                options: {
-                  apiKey,
-                  ...(baseURL ? { baseURL } : {}),
-                },
-              },
-            ]),
-          ),
-        }
-      : undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const providerConfig: Record<string, any> = {};
+
+  // Standard providers: inject apiKey + optional baseURL
+  for (const [id, { apiKey, baseURL }] of Object.entries(providers)) {
+    if (!apiKey) continue;
+    providerConfig[id] = {
+      options: { apiKey, ...(baseURL ? { baseURL } : {}) },
+    };
+  }
+
+  // Custom providers (e.g. Ollama): inject full definition with npm, api, models
+  for (const [id, def] of Object.entries(customProviders)) {
+    providerConfig[id] = {
+      id: def.id,
+      name: def.name,
+      npm: def.npm,
+      api: def.api,
+      options: { apiKey: def.apiKey ?? "none" },
+      models: def.models,
+    };
+  }
+
+  const hasEntries = Object.keys(providerConfig).length > 0;
 
   return {
     ...process.env,
-    ...(opencodeConfigContent
+    ...(hasEntries
       ? {
-          OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfigContent),
+          OPENCODE_CONFIG_CONTENT: JSON.stringify({
+            provider: providerConfig,
+          }),
         }
       : {}),
   };

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -172,11 +172,39 @@ export interface ProviderConfig {
   opencodeConfig?: {
     /** Per-sub-provider API keys injected via OPENCODE_CONFIG_CONTENT env var */
     providers?: Record<string, { apiKey: string; baseURL?: string }>;
+    /** Custom provider definitions (e.g. Ollama) injected into OPENCODE_CONFIG_CONTENT */
+    customProviders?: Record<string, OpencodeCustomProvider>;
     /** Port override (default: derived from cwd hash, range 8200–8998) */
     port?: number;
     /** Path to opencode binary (defaults to PATH lookup) */
     binaryPath?: string;
   };
+}
+
+/** Full provider definition for opencode providers not in the built-in registry (e.g. Ollama) */
+export interface OpencodeCustomProvider {
+  id: string;
+  name: string;
+  /** npm package for the AI SDK adapter (e.g. "@ai-sdk/openai-compatible") */
+  npm: string;
+  /** Base API URL (e.g. "http://localhost:11434/v1") */
+  api: string;
+  /** API key (dummy for local providers like Ollama) */
+  apiKey?: string;
+  /** Model definitions keyed by model ID */
+  models: Record<
+    string,
+    {
+      id: string;
+      name: string;
+      tool_call?: boolean;
+      temperature?: boolean;
+      reasoning?: boolean;
+      /** Vision/image input support */
+      attachment?: boolean;
+      limit?: { context?: number; output?: number };
+    }
+  >;
 }
 
 export interface TokenUsage {

--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -65,6 +65,12 @@ export const IPC_CHANNELS = {
   OPENCODE_GET_MODEL_ALLOWLIST: "integration:opencode:get-model-allowlist",
   OPENCODE_SET_MODEL_ALLOWLIST: "integration:opencode:set-model-allowlist",
 
+  // Ollama — local model server
+  OLLAMA_GET_CONFIG: "integration:ollama:get-config",
+  OLLAMA_SET_CONFIG: "integration:ollama:set-config",
+  OLLAMA_CLEAR_CONFIG: "integration:ollama:clear-config",
+  OLLAMA_DISCOVER_MODELS: "integration:ollama:discover-models",
+
   // Interactive tool events (AskUserQuestion, plan mode)
   ASK_USER_QUESTION: "chat:ask-user-question",
   ASK_USER_RESPONSE: "chat:ask-user-response",

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -34,7 +34,11 @@ import {
   deleteOpencodeProviderKey,
   getOpencodeModelAllowlist,
   setOpencodeModelAllowlist,
+  getOllamaConfig,
+  setOllamaConfig,
+  clearOllamaConfig,
 } from "./settings/settings.store";
+import type { OllamaConfig, OllamaModelInfo } from "./settings/settings.store";
 import { resolveToolBehavior, effectiveToolName } from "./agent-session-logic";
 import { resolveClaudePathOrUndefined } from "./integrations/claude-path";
 import { getScheduleMcpPath } from "./scheduler/scheduler";
@@ -98,6 +102,136 @@ function safeLog(fn: (...args: unknown[]) => void, ...args: unknown[]) {
   } catch (e: any) {
     if (e?.code !== "EPIPE") throw e;
   }
+}
+
+// ─── Ollama helpers ─────────────────────────────────────────────────────────
+
+function extractContextLength(
+  modelInfo: Record<string, unknown>,
+  family: string,
+): number | undefined {
+  // Try family-specific key first (e.g. "gemma4.context_length")
+  const familyKey = `${family}.context_length`;
+  if (typeof modelInfo[familyKey] === "number") {
+    return modelInfo[familyKey] as number;
+  }
+  // Fallback: search for any key ending in ".context_length"
+  for (const [key, value] of Object.entries(modelInfo)) {
+    if (key.endsWith(".context_length") && typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Discover Ollama models via /api/tags + /api/show per model.
+ * Returns enriched model info with capabilities and context window.
+ */
+async function discoverOllamaModels(
+  baseURL: string,
+): Promise<OllamaModelInfo[]> {
+  const tagsResp = await fetch(`${baseURL}/api/tags`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!tagsResp.ok) {
+    throw new Error(`Ollama not reachable at ${baseURL} (${tagsResp.status})`);
+  }
+  const { models } = (await tagsResp.json()) as {
+    models: {
+      name: string;
+      size: number;
+      details?: {
+        family?: string;
+        parameter_size?: string;
+        quantization_level?: string;
+      };
+    }[];
+  };
+
+  // Enrich each model with capabilities + context window from /api/show
+  return Promise.all(
+    models.map(async (m) => {
+      const family = m.details?.family ?? "";
+      try {
+        const showResp = await fetch(`${baseURL}/api/show`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: m.name }),
+          signal: AbortSignal.timeout(5000),
+        });
+        const show = (await showResp.json()) as {
+          capabilities?: string[];
+          model_info?: Record<string, unknown>;
+        };
+        const caps: string[] = show.capabilities ?? [];
+        const ctxLen = extractContextLength(show.model_info ?? {}, family);
+
+        return {
+          name: m.name,
+          size: m.size,
+          parameterSize: m.details?.parameter_size ?? "unknown",
+          family,
+          quantization: m.details?.quantization_level ?? "unknown",
+          capabilities: {
+            vision: caps.includes("vision"),
+            tools: caps.includes("tools"),
+            thinking: caps.includes("thinking"),
+          },
+          contextLength: ctxLen ?? 131072,
+        };
+      } catch {
+        // If /api/show fails for a model, return with safe defaults
+        return {
+          name: m.name,
+          size: m.size,
+          parameterSize: m.details?.parameter_size ?? "unknown",
+          family,
+          quantization: m.details?.quantization_level ?? "unknown",
+          capabilities: { vision: false, tools: true, thinking: false },
+          contextLength: 131072,
+        };
+      }
+    }),
+  );
+}
+
+/**
+ * Build custom opencode provider definition for Ollama, if configured.
+ */
+function buildOllamaCustomProvider(): Record<
+  string,
+  import("@stratosapp/core").OpencodeCustomProvider
+> {
+  const config = getOllamaConfig();
+  if (!config || Object.keys(config.models).length === 0) return {};
+
+  return {
+    ollama: {
+      id: "ollama",
+      name: "Ollama",
+      npm: "@ai-sdk/openai-compatible",
+      api: `${config.baseURL}/v1`,
+      apiKey: "ollama",
+      models: Object.fromEntries(
+        Object.entries(config.models).map(([id, m]) => [
+          id,
+          {
+            id,
+            name: `${m.name} (${m.parameterSize})`,
+            tool_call: m.capabilities.tools,
+            temperature: true,
+            reasoning: m.capabilities.thinking,
+            attachment: m.capabilities.vision,
+            limit: {
+              context: m.contextLength,
+              output: 8192,
+            },
+          },
+        ]),
+      ),
+    },
+  };
 }
 
 interface ThreadSession {
@@ -251,7 +385,10 @@ export class AgentManager {
             : undefined;
         const opencodeConfig =
           key === "opencode"
-            ? { providers: getOpencodeProviderKeys() }
+            ? {
+                providers: getOpencodeProviderKeys(),
+                customProviders: buildOllamaCustomProvider(),
+              }
             : undefined;
         await provider.initialize({
           cliPath,
@@ -557,6 +694,34 @@ export class AgentManager {
         this.modelsCache.delete("opencode");
       },
     );
+
+    // Ollama — local model server
+    ipcMain.handle(IPC_CHANNELS.OLLAMA_GET_CONFIG, async () => {
+      return getOllamaConfig();
+    });
+
+    ipcMain.handle(
+      IPC_CHANNELS.OLLAMA_SET_CONFIG,
+      async (_event, config: OllamaConfig) => {
+        setOllamaConfig(config);
+        // Restart opencode server so it picks up the new Ollama provider
+        OpencodeProvider.restartServer();
+        this.modelsCache.delete("opencode");
+      },
+    );
+
+    ipcMain.handle(IPC_CHANNELS.OLLAMA_CLEAR_CONFIG, async () => {
+      clearOllamaConfig();
+      OpencodeProvider.restartServer();
+      this.modelsCache.delete("opencode");
+    });
+
+    ipcMain.handle(
+      IPC_CHANNELS.OLLAMA_DISCOVER_MODELS,
+      async (_event, baseURL: string) => {
+        return discoverOllamaModels(baseURL);
+      },
+    );
   }
 
   private async runStream(
@@ -712,7 +877,12 @@ export class AgentManager {
             }
           : {}),
         ...(providerName === "opencode"
-          ? { opencodeConfig: { providers: getOpencodeProviderKeys() } }
+          ? {
+              opencodeConfig: {
+                providers: getOpencodeProviderKeys(),
+                customProviders: buildOllamaCustomProvider(),
+              },
+            }
           : {}),
         model: thread.model,
         cwd: threadCwd,
@@ -1331,7 +1501,12 @@ export class AgentManager {
             }
           : {}),
         ...(providerName === "opencode"
-          ? { opencodeConfig: { providers: getOpencodeProviderKeys() } }
+          ? {
+              opencodeConfig: {
+                providers: getOpencodeProviderKeys(),
+                customProviders: buildOllamaCustomProvider(),
+              },
+            }
           : {}),
         model: thread.model,
         cwd: threadCwd,

--- a/packages/desktop/src/main/settings/settings.store.ts
+++ b/packages/desktop/src/main/settings/settings.store.ts
@@ -15,6 +15,27 @@ export interface OpencodeProviderKey {
   baseURL?: string;
 }
 
+/** Per-model metadata discovered from Ollama's /api/show endpoint */
+export interface OllamaModelInfo {
+  name: string;
+  size: number;
+  parameterSize: string;
+  family: string;
+  quantization: string;
+  capabilities: {
+    vision: boolean;
+    tools: boolean;
+    thinking: boolean;
+  };
+  contextLength: number;
+}
+
+/** Ollama configuration persisted in app-settings.json */
+export interface OllamaConfig {
+  baseURL: string;
+  models: Record<string, OllamaModelInfo>;
+}
+
 export interface AppSettings {
   theme?: AppTheme;
   providers?: Record<string, ProviderPrefs>;
@@ -23,6 +44,8 @@ export interface AppSettings {
   /** Allowlist of opencode sub-provider IDs whose models are shown in the picker.
    *  If undefined, DEFAULT_OPENCODE_MODEL_ALLOWLIST is used. */
   opencodeModelAllowlist?: string[];
+  /** Ollama local model server configuration */
+  ollamaConfig?: OllamaConfig;
   [key: string]: unknown;
 }
 
@@ -131,4 +154,20 @@ export function getOpencodeModelAllowlist(): string[] {
 export function setOpencodeModelAllowlist(allowlist: string[]): void {
   const current = loadSettings();
   saveSettings({ ...current, opencodeModelAllowlist: allowlist });
+}
+
+export function getOllamaConfig(): OllamaConfig | undefined {
+  const settings = loadSettings();
+  return settings.ollamaConfig;
+}
+
+export function setOllamaConfig(config: OllamaConfig): void {
+  const current = loadSettings();
+  saveSettings({ ...current, ollamaConfig: config });
+}
+
+export function clearOllamaConfig(): void {
+  const current = loadSettings();
+  const { ollamaConfig: _, ...rest } = current;
+  saveSettings(rest as AppSettings);
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -234,6 +234,16 @@ const api = {
   opencodeSetModelAllowlist: (allowlist: string[]): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.OPENCODE_SET_MODEL_ALLOWLIST, allowlist),
 
+  // Ollama — local model server
+  ollamaGetConfig: (): Promise<unknown> =>
+    ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_GET_CONFIG),
+  ollamaSetConfig: (config: unknown): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_SET_CONFIG, config),
+  ollamaClearConfig: (): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_CLEAR_CONFIG),
+  ollamaDiscoverModels: (baseURL: string): Promise<unknown[]> =>
+    ipcRenderer.invoke(IPC_CHANNELS.OLLAMA_DISCOVER_MODELS, baseURL),
+
   // Folders
   foldersList: (): Promise<Folder[]> =>
     ipcRenderer.invoke(IPC_CHANNELS.FOLDERS_LIST),

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -51,6 +51,7 @@ import { ConnectGitHubDialog } from "./components/ConnectGitHubDialog";
 import { ConnectClaudeDialog } from "./components/ConnectClaudeDialog";
 import { ConnectCodexDialog } from "./components/ConnectCodexDialog";
 import { OpencodeSettingsDialog } from "./components/OpencodeSettingsDialog";
+import { OllamaSettingsDialog } from "./components/OllamaSettingsDialog";
 import { SettingsDialog } from "./components/SettingsDialog";
 import { ScheduledPromptsDialog } from "./components/ScheduledPromptsDialog";
 import { NewThreadDialog } from "./components/NewThreadDialog";
@@ -139,6 +140,7 @@ function AppInner(): React.ReactElement {
   const [showGitHubDialog, setShowGitHubDialog] = useState(false);
   const [showCodexDialog, setShowCodexDialog] = useState(false);
   const [showOpencodeDialog, setShowOpencodeDialog] = useState(false);
+  const [showOllamaDialog, setShowOllamaDialog] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [showSchedulesDialog, setShowSchedulesDialog] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">("dark");
@@ -992,6 +994,14 @@ function AppInner(): React.ReactElement {
                         </span>
                       </button>
                       <button
+                        onClick={() => setShowOllamaDialog(true)}
+                        className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
+                        title="Ollama local models"
+                      >
+                        <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />
+                        <span className="text-[var(--text-muted)]">Ollama</span>
+                      </button>
+                      <button
                         onClick={() => setShowGitHubDialog(true)}
                         className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
                         title={
@@ -1245,6 +1255,12 @@ function AppInner(): React.ReactElement {
         <OpencodeSettingsDialog
           isOpen={showOpencodeDialog}
           onClose={() => setShowOpencodeDialog(false)}
+        />
+
+        {/* Ollama settings dialog */}
+        <OllamaSettingsDialog
+          isOpen={showOllamaDialog}
+          onClose={() => setShowOllamaDialog(false)}
         />
 
         {/* GitHub connect dialog */}

--- a/packages/desktop/src/renderer/components/OllamaSettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/OllamaSettingsDialog.tsx
@@ -1,0 +1,344 @@
+import { useState, useCallback, useEffect } from "react";
+import { Dialog, DialogBody, Button } from "@stratosapp/ui";
+
+interface OllamaModelInfo {
+  name: string;
+  size: number;
+  parameterSize: string;
+  family: string;
+  quantization: string;
+  capabilities: {
+    vision: boolean;
+    tools: boolean;
+    thinking: boolean;
+  };
+  contextLength: number;
+}
+
+interface OllamaConfig {
+  baseURL: string;
+  models: Record<string, OllamaModelInfo>;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1e9) return `${(bytes / 1e6).toFixed(0)} MB`;
+  return `${(bytes / 1e9).toFixed(1)} GB`;
+}
+
+function capBadges(caps: OllamaModelInfo["capabilities"]): string[] {
+  const tags: string[] = [];
+  if (caps.tools) tags.push("tools");
+  if (caps.vision) tags.push("vision");
+  if (caps.thinking) tags.push("thinking");
+  return tags;
+}
+
+export function OllamaSettingsDialog({
+  isOpen,
+  onClose,
+}: Props): React.ReactElement | null {
+  const [baseURL, setBaseURL] = useState("http://localhost:11434");
+  const [config, setConfig] = useState<OllamaConfig | null>(null);
+  const [discovered, setDiscovered] = useState<OllamaModelInfo[]>([]);
+  const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  // Load existing config on open
+  useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    setSaved(false);
+    setDiscovered([]);
+    window.api
+      .ollamaGetConfig()
+      .then((cfg: unknown) => {
+        const c = cfg as OllamaConfig | undefined;
+        if (c) {
+          setConfig(c);
+          setBaseURL(c.baseURL);
+          setSelectedModels(new Set(Object.keys(c.models)));
+        } else {
+          setConfig(null);
+          setSelectedModels(new Set());
+        }
+      })
+      .catch(() => {});
+  }, [isOpen]);
+
+  const handleDiscover = useCallback(async () => {
+    setDiscovering(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const models = (await window.api.ollamaDiscoverModels(
+        baseURL,
+      )) as OllamaModelInfo[];
+      setDiscovered(models);
+      // Auto-select all discovered models
+      setSelectedModels(new Set(models.map((m) => m.name)));
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to connect to Ollama. Is it running?",
+      );
+      setDiscovered([]);
+    } finally {
+      setDiscovering(false);
+    }
+  }, [baseURL]);
+
+  const toggleModel = useCallback((name: string) => {
+    setSelectedModels((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+    setSaved(false);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Build models map from discovered + selected
+      const allModels = discovered.length > 0 ? discovered : [];
+      // Also include existing config models for models not re-discovered
+      const existingModels = config?.models ?? {};
+      const models: Record<string, OllamaModelInfo> = {};
+
+      for (const m of allModels) {
+        if (selectedModels.has(m.name)) {
+          models[m.name] = m;
+        }
+      }
+      // Keep existing models that are still selected but weren't re-discovered
+      for (const [name, info] of Object.entries(existingModels)) {
+        if (selectedModels.has(name) && !models[name]) {
+          models[name] = info;
+        }
+      }
+
+      const newConfig: OllamaConfig = { baseURL, models };
+      await window.api.ollamaSetConfig(newConfig);
+      setConfig(newConfig);
+
+      // Auto-add "ollama" to model allowlist
+      try {
+        const allowlist =
+          (await window.api.opencodeGetModelAllowlist?.()) ?? [];
+        if (!allowlist.includes("ollama")) {
+          await window.api.opencodeSetModelAllowlist?.([
+            ...allowlist,
+            "ollama",
+          ]);
+        }
+      } catch {
+        // Non-critical
+      }
+
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save config");
+    } finally {
+      setLoading(false);
+    }
+  }, [baseURL, discovered, selectedModels, config]);
+
+  const handleRemove = useCallback(async () => {
+    setLoading(true);
+    try {
+      await window.api.ollamaClearConfig();
+      setConfig(null);
+      setDiscovered([]);
+      setSelectedModels(new Set());
+      setSaved(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to clear config");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Models to display: discovered takes priority, otherwise existing config
+  const displayModels =
+    discovered.length > 0 ? discovered : Object.values(config?.models ?? {});
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Ollama Settings">
+      <DialogBody>
+        <div className="space-y-4">
+          <p className="text-xs text-[var(--text-muted)]">
+            Connect to a local Ollama server to use open-source models with the
+            Opencode provider.
+          </p>
+
+          {/* Base URL */}
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-[var(--text-control)] uppercase tracking-wide">
+              Ollama Server URL
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={baseURL}
+                onChange={(e) => {
+                  setBaseURL(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="http://localhost:11434"
+                className="flex-1 px-2 py-1.5 text-xs rounded-md bg-[var(--bg-surface)] border border-[var(--border)] text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--text-control)]"
+              />
+              <Button
+                onClick={handleDiscover}
+                disabled={discovering || !baseURL.trim()}
+                size="sm"
+              >
+                {discovering ? "Scanning..." : "Discover Models"}
+              </Button>
+            </div>
+          </div>
+
+          {/* Model list */}
+          {displayModels.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-[var(--text-control)] uppercase tracking-wide">
+                Available Models
+              </p>
+              <div className="space-y-1.5 max-h-64 overflow-y-auto">
+                {displayModels.map((m) => {
+                  const isSelected = selectedModels.has(m.name);
+                  const badges = capBadges(m.capabilities);
+                  return (
+                    <button
+                      key={m.name}
+                      onClick={() => toggleModel(m.name)}
+                      className={`w-full text-left p-2 rounded-md border transition-colors ${
+                        isSelected
+                          ? "bg-[var(--bg-surface)] border-[var(--text-control)]"
+                          : "bg-transparent border-[var(--border)] opacity-50"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <div
+                            className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                              isSelected ? "bg-green-500" : "bg-gray-500"
+                            }`}
+                          />
+                          <span className="text-xs font-medium text-[var(--text-primary)] truncate">
+                            {m.name}
+                          </span>
+                        </div>
+                        <span className="text-[10px] text-[var(--text-muted)] flex-shrink-0">
+                          {m.parameterSize} &middot; {formatBytes(m.size)}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1.5 mt-1 ml-4">
+                        <span className="text-[10px] text-[var(--text-muted)]">
+                          {Math.round(m.contextLength / 1024)}k ctx
+                        </span>
+                        {badges.map((b) => (
+                          <span
+                            key={b}
+                            className="text-[10px] px-1 py-0.5 rounded bg-[var(--border)] text-[var(--text-muted)]"
+                          >
+                            {b}
+                          </span>
+                        ))}
+                        <span className="text-[10px] text-[var(--text-muted)]">
+                          {m.quantization}
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
+          {displayModels.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={handleSave}
+                disabled={loading || selectedModels.size === 0}
+                size="sm"
+              >
+                {loading
+                  ? "Saving..."
+                  : saved
+                    ? "Saved!"
+                    : `Enable ${selectedModels.size} Model${selectedModels.size !== 1 ? "s" : ""}`}
+              </Button>
+              {config && (
+                <button
+                  onClick={handleRemove}
+                  disabled={loading}
+                  className="text-xs text-[var(--text-muted)] hover:text-red-400 transition-colors"
+                >
+                  Remove Ollama
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Status indicator */}
+          {config && displayModels.length === 0 && (
+            <div className="flex items-center justify-between gap-2 p-2 rounded-md bg-[var(--bg-surface)] border border-[var(--border)]">
+              <div className="flex items-center gap-2">
+                <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                <p className="text-xs text-[var(--text-primary)]">
+                  Ollama configured ({Object.keys(config.models).length} model
+                  {Object.keys(config.models).length !== 1 ? "s" : ""})
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleDiscover}
+                  disabled={discovering}
+                  className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  Refresh
+                </button>
+                <button
+                  onClick={handleRemove}
+                  disabled={loading}
+                  className="text-xs text-[var(--text-muted)] hover:text-red-400 transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <p className="text-xs text-red-400 bg-red-400/10 px-2 py-1.5 rounded-md">
+              {error}
+            </p>
+          )}
+
+          {/* Empty state */}
+          {!config && displayModels.length === 0 && !error && (
+            <p className="text-xs text-[var(--text-muted)] text-center py-2">
+              Click &quot;Discover Models&quot; to scan your local Ollama
+              server.
+            </p>
+          )}
+        </div>
+      </DialogBody>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Enable local Ollama models (e.g. `gemma4:26b`) through the Opencode provider
- Ollama is injected as a custom opencode sub-provider using `@ai-sdk/openai-compatible`, reusing opencode's full agent/tool engine
- Auto-detect model capabilities (vision, tools, thinking) and context window from Ollama's `/api/show` endpoint
- New Ollama Settings dialog with model discovery, capability badges, and one-click enable

## Changes
- **Core types**: `OpencodeCustomProvider` interface, extended `opencodeConfig`
- **`buildOpencodeEnv()`**: Merges custom provider definitions into `OPENCODE_CONFIG_CONTENT`
- **Settings store**: `OllamaConfig` type with CRUD helpers
- **Agent manager**: `discoverOllamaModels()`, `buildOllamaCustomProvider()`, IPC handlers
- **UI**: `OllamaSettingsDialog` with URL config, model discovery, capability badges
- **App.tsx**: Ollama button (orange dot) in integration bar

## Test plan
- [x] Build succeeds with zero errors
- [x] Ollama Settings dialog opens, discovers models from local Ollama server
- [x] Model capabilities (tools, vision, thinking) and context window (262k) correctly detected
- [x] `ollama/gemma4:26b` appears in model picker under Opencode provider
- [x] Messages sent to Ollama model get streaming responses with reasoning support
- [x] Config persisted to `~/.stratos/app-settings.json`
- [x] "ollama" auto-added to model allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)