### PR TITLE
fix(opencode-settings): Ollama Manage checkbox + drop duplicate top-bar Ollama button

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -152,9 +152,6 @@ function AppInner(): React.ReactElement {
   const [showGitHubDialog, setShowGitHubDialog] = useState(false);
   const [showCodexDialog, setShowCodexDialog] = useState(false);
   const [showOpencodeDialog, setShowOpencodeDialog] = useState(false);
-  const [opencodeInitialAddId, setOpencodeInitialAddId] = useState<
-    string | undefined
-  >(undefined);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [showSchedulesDialog, setShowSchedulesDialog] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">("dark");
@@ -1026,10 +1023,7 @@ function AppInner(): React.ReactElement {
                         </span>
                       </button>
                       <button
-                        onClick={() => {
-                          setOpencodeInitialAddId(undefined);
-                          setShowOpencodeDialog(true);
-                        }}
+                        onClick={() => setShowOpencodeDialog(true)}
                         className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
                         title="Opencode settings"
                       >
@@ -1037,17 +1031,6 @@ function AppInner(): React.ReactElement {
                         <span className="text-[var(--text-muted)]">
                           Opencode
                         </span>
-                      </button>
-                      <button
-                        onClick={() => {
-                          setOpencodeInitialAddId("ollama");
-                          setShowOpencodeDialog(true);
-                        }}
-                        className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
-                        title="Ollama local models"
-                      >
-                        <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />
-                        <span className="text-[var(--text-muted)]">Ollama</span>
                       </button>
                       <button
                         onClick={() => setShowGitHubDialog(true)}
@@ -1303,7 +1286,6 @@ function AppInner(): React.ReactElement {
         <OpencodeSettingsDialog
           isOpen={showOpencodeDialog}
           onClose={() => setShowOpencodeDialog(false)}
-          initialAddProviderId={opencodeInitialAddId}
         />
 
         {/* GitHub connect dialog */}

--- a/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
@@ -319,13 +319,17 @@ function ProviderRow({
 }: ProviderRowProps): React.ReactElement {
   return (
     <div
-      className="flex items-center gap-2 p-2 rounded-md bg-[var(--bg-surface)] border border-[var(--border)]"
+      className="flex items-center gap-3 px-3 py-2 rounded-md bg-[var(--bg-surface)] border border-[var(--border)]"
       data-testid={`opencode-row-${id}`}
     >
       <div
-        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-          enabled && modelCount > 0 ? "bg-green-500" : "bg-gray-500"
-        }`}
+        className="flex-shrink-0 rounded-full"
+        style={{
+          width: 6,
+          height: 6,
+          backgroundColor:
+            enabled && modelCount > 0 ? "#22c55e" : "var(--border)",
+        }}
       />
       <div className="flex-1 min-w-0">
         <p className="text-xs font-medium text-[var(--text-primary)] truncate">
@@ -337,34 +341,64 @@ function ProviderRow({
           {modelCount} model{modelCount === 1 ? "" : "s"}
         </p>
       </div>
-      <button
-        role="switch"
-        aria-checked={enabled}
-        aria-label={`${enabled ? "Disable" : "Enable"} ${label}`}
-        onClick={() => onToggle(!enabled)}
-        className={`w-8 h-4 rounded-full transition-colors flex-shrink-0 relative ${
-          enabled ? "bg-green-600" : "bg-[var(--border)]"
-        }`}
-      >
-        <span
-          className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
-            enabled ? "translate-x-4" : "translate-x-0.5"
-          }`}
-        />
-      </button>
+      <Toggle
+        enabled={enabled}
+        onToggle={onToggle}
+        ariaLabel={`${enabled ? "Disable" : "Enable"} ${label}`}
+      />
       <button
         onClick={onManage}
-        className="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0 px-1"
+        className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0"
       >
         Manage
       </button>
       <button
         onClick={onRemove}
-        className="text-[10px] text-[var(--text-muted)] hover:text-red-400 transition-colors flex-shrink-0 px-1"
+        className="text-[11px] text-[var(--text-muted)] hover:text-red-400 transition-colors flex-shrink-0"
       >
         Remove
       </button>
     </div>
+  );
+}
+
+function Toggle({
+  enabled,
+  onToggle,
+  ariaLabel,
+}: {
+  enabled: boolean;
+  onToggle: (next: boolean) => void;
+  ariaLabel: string;
+}): React.ReactElement {
+  const TRACK_W = 28;
+  const TRACK_H = 16;
+  const KNOB = 12;
+  const PAD = 2;
+  return (
+    <button
+      role="switch"
+      aria-checked={enabled}
+      aria-label={ariaLabel}
+      onClick={() => onToggle(!enabled)}
+      className="flex-shrink-0 relative rounded-full transition-colors p-0 border-0 cursor-pointer"
+      style={{
+        width: TRACK_W,
+        height: TRACK_H,
+        backgroundColor: enabled ? "#16a34a" : "var(--border)",
+      }}
+    >
+      <span
+        className="absolute rounded-full bg-white transition-all"
+        style={{
+          width: KNOB,
+          height: KNOB,
+          top: (TRACK_H - KNOB) / 2,
+          left: enabled ? TRACK_W - KNOB - PAD : PAD,
+          boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
+        }}
+      />
+    </button>
   );
 }
 

--- a/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
@@ -446,9 +446,15 @@ function AddProviderPanel({
 
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [ollamaModels, setOllamaModels] = useState<OllamaModelInfo[]>([]);
-  const [selected, setSelected] = useState<Set<string>>(
-    new Set(existingSelection),
-  );
+  // Ollama rows toggle on bare model name (e.g. "gemma4:latest") while the
+  // stored selection uses fully-qualified values (e.g. "ollama/gemma4:latest").
+  // Strip the provider prefix so the checkbox reflects the saved state.
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    if (editing && fixedProviderId === "ollama") {
+      return new Set(existingSelection.map((v) => v.replace(/^ollama\//, "")));
+    }
+    return new Set(existingSelection);
+  });
   const [fetching, setFetching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Ollama stores enabled models as fully-qualified values (`ollama/name`) but the row toggles on the bare name, so existing selections rendered unchecked in Manage. Strip the `ollama/` prefix when seeding the selected Set in edit mode.
- Remove the separate Ollama entry from the top bar — Ollama is a provider *under* Opencode, not a standalone integration. Everything is now reachable through the unified Opencode Settings dialog.

## Test plan
- [x] Visually verified via Chrome DevTools MCP: Ollama row shows "1 model"; Manage opens with the model's checkbox ticked and row highlighted.
- [x] Verified the top-bar no longer shows a separate Ollama button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)