### PR TITLE
fix(opencode): auto-detect wedged server + restart on chat / model-list drift

### DIFF
--- a/packages/core/src/providers/opencode.provider.ts
+++ b/packages/core/src/providers/opencode.provider.ts
@@ -493,10 +493,51 @@ export class OpencodeProvider implements AgentProvider {
     }
   }
 
+  /** Cheap liveness probe. Returns true if the server responds to /provider. */
+  async healthCheck(): Promise<boolean> {
+    if (!this.baseUrl) return false;
+    try {
+      const resp = await fetch(`${this.baseUrl}/provider`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+      return resp.ok || resp.status === 404;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Recover from a dead / wedged / stale-env server. Kills anything on the
+   * port and re-runs initialize() with the provider's current config, which
+   * spawns a fresh process with the up-to-date env (API keys, Ollama config).
+   */
+  async recoverServer(): Promise<void> {
+    if (!this.config || this.port === null) return;
+    console.warn(
+      `[opencode] recovering server on port ${this.port} (restart + reinit)`,
+    );
+    OpencodeProvider.restartServer(this.port);
+    this.baseUrl = null;
+    const port = this.port;
+    this.port = null;
+    await this.initialize({
+      ...this.config,
+      opencodeConfig: { ...(this.config.opencodeConfig ?? {}), port },
+    });
+  }
+
   // ── Messaging ──────────────────────────────────────────────────────────────
 
   async *sendMessage(params: SendMessageParams): AsyncGenerator<AgentMessage> {
     if (!this.baseUrl) throw new Error("OpencodeProvider not initialized");
+
+    // Auto-recover from a dead server before we start streaming. If the
+    // server is wedged or was killed externally, restart it once and retry.
+    // After an event has been yielded we can't safely retry, so the check
+    // only runs here at the start.
+    if (!(await this.healthCheck())) {
+      await this.recoverServer();
+    }
 
     this.abortController = new AbortController();
 

--- a/packages/core/src/providers/opencode.provider.ts
+++ b/packages/core/src/providers/opencode.provider.ts
@@ -392,6 +392,36 @@ export class OpencodeProvider implements AgentProvider {
     const binaryPath = resolveOpencodeBinary(config.opencodeConfig?.binaryPath);
     const env = buildOpencodeEnv(config);
 
+    // If a stale opencode server from a prior run is holding our port, kill
+    // it before spawning. Otherwise waitForServerReady will adopt the zombie
+    // via HTTP probe and we'd be stuck with whatever env it was started with
+    // (e.g. without the current Ollama config).
+    try {
+      const existingPids = execSync(`lsof -ti :${port} -sTCP:LISTEN`, {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      for (const pid of existingPids) {
+        try {
+          process.kill(parseInt(pid, 10), "SIGTERM");
+          console.log(
+            `[opencode] killed stale listener on port ${port} (pid=${pid})`,
+          );
+        } catch {
+          // pid may have exited between lsof and kill; ignore
+        }
+      }
+      if (existingPids.length > 0) {
+        // Give the OS a moment to release the port
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    } catch {
+      // lsof returned non-zero (no listener) — nothing to kill
+    }
+
     console.log(
       `[opencode] starting server on port ${port} (binary: ${binaryPath})`,
     );

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -41,6 +41,7 @@
     "@xterm/xterm": "^6.0.0",
     "node-cron": "^4.2.1",
     "node-pty": "^1.1.0",
+    "ollama": "^0.6.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -111,17 +111,31 @@ function safeLog(fn: (...args: unknown[]) => void, ...args: unknown[]) {
 
 // ─── Ollama helpers ─────────────────────────────────────────────────────────
 
+/**
+ * Reads `{family}.context_length` out of Ollama's model_info bag. The field
+ * may arrive as a plain object (Ollama REST JSON) or a Map (ollama-js typing);
+ * handle both.
+ */
 function extractContextLength(
-  modelInfo: Record<string, unknown>,
+  modelInfo: unknown,
   family: string,
 ): number | undefined {
-  // Try family-specific key first (e.g. "gemma4.context_length")
-  const familyKey = `${family}.context_length`;
-  if (typeof modelInfo[familyKey] === "number") {
-    return modelInfo[familyKey] as number;
-  }
-  // Fallback: search for any key ending in ".context_length"
-  for (const [key, value] of Object.entries(modelInfo)) {
+  const read = (key: string): unknown => {
+    if (modelInfo instanceof Map) return modelInfo.get(key);
+    if (modelInfo && typeof modelInfo === "object") {
+      return (modelInfo as Record<string, unknown>)[key];
+    }
+    return undefined;
+  };
+  const direct = read(`${family}.context_length`);
+  if (typeof direct === "number") return direct;
+  const entries =
+    modelInfo instanceof Map
+      ? Array.from(modelInfo.entries())
+      : modelInfo && typeof modelInfo === "object"
+        ? Object.entries(modelInfo as Record<string, unknown>)
+        : [];
+  for (const [key, value] of entries) {
     if (key.endsWith(".context_length") && typeof value === "number") {
       return value;
     }
@@ -130,69 +144,45 @@ function extractContextLength(
 }
 
 /**
- * Discover Ollama models via /api/tags + /api/show per model.
- * Returns enriched model info with capabilities and context window.
+ * Discover Ollama models via the official `ollama` SDK (typed wrapper around
+ * `/api/tags` + `/api/show`). Returns enriched model info with capabilities
+ * and context window.
  */
 async function discoverOllamaModels(
   baseURL: string,
 ): Promise<OllamaModelInfo[]> {
-  const tagsResp = await fetch(`${baseURL}/api/tags`, {
-    signal: AbortSignal.timeout(5000),
-  });
-  if (!tagsResp.ok) {
-    throw new Error(`Ollama not reachable at ${baseURL} (${tagsResp.status})`);
-  }
-  const { models } = (await tagsResp.json()) as {
-    models: {
-      name: string;
-      size: number;
-      details?: {
-        family?: string;
-        parameter_size?: string;
-        quantization_level?: string;
-      };
-    }[];
-  };
+  const { Ollama } = await import("ollama");
+  const client = new Ollama({ host: baseURL });
 
-  // Enrich each model with capabilities + context window from /api/show
+  const { models } = await client.list();
+
   return Promise.all(
     models.map(async (m) => {
       const family = m.details?.family ?? "";
+      const base = {
+        name: m.name,
+        size: m.size,
+        parameterSize: m.details?.parameter_size ?? "unknown",
+        family,
+        quantization: m.details?.quantization_level ?? "unknown",
+      };
       try {
-        const showResp = await fetch(`${baseURL}/api/show`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: m.name }),
-          signal: AbortSignal.timeout(5000),
-        });
-        const show = (await showResp.json()) as {
-          capabilities?: string[];
-          model_info?: Record<string, unknown>;
-        };
-        const caps: string[] = show.capabilities ?? [];
-        const ctxLen = extractContextLength(show.model_info ?? {}, family);
-
+        const show = await client.show({ model: m.name });
+        const caps = show.capabilities ?? [];
         return {
-          name: m.name,
-          size: m.size,
-          parameterSize: m.details?.parameter_size ?? "unknown",
-          family,
-          quantization: m.details?.quantization_level ?? "unknown",
+          ...base,
           capabilities: {
             vision: caps.includes("vision"),
             tools: caps.includes("tools"),
             thinking: caps.includes("thinking"),
           },
-          contextLength: ctxLen ?? 131072,
+          contextLength:
+            extractContextLength(show.model_info, family) ?? 131072,
         };
       } catch {
-        // If /api/show fails for a model, return with safe defaults
+        // If show() fails for a model, return with safe defaults
         return {
-          name: m.name,
-          size: m.size,
-          parameterSize: m.details?.parameter_size ?? "unknown",
-          family,
-          quantization: m.details?.quantization_level ?? "unknown",
+          ...base,
           capabilities: { vision: false, tools: true, thinking: false },
           contextLength: 131072,
         };

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -370,7 +370,7 @@ export class AgentManager {
         ) {
           return cached.models;
         }
-        const provider = createProvider(key as ProviderType);
+        let provider = createProvider(key as ProviderType);
         const settings = loadSettings();
         const cliPath =
           key === "claude-code"
@@ -392,6 +392,33 @@ export class AgentManager {
         try {
           let models = await provider.getAvailableModels();
           if (key === "opencode") {
+            // Drift detection: if a sub-provider we configured (API key or
+            // Ollama) is missing from the server's /provider response, the
+            // server is running with stale env. Restart + refetch once.
+            const ollama = getOllamaConfig();
+            const expected = new Set<string>([
+              ...Object.keys(getOpencodeProviderKeys()),
+              ...(ollama && Object.keys(ollama.models).length > 0
+                ? ["ollama"]
+                : []),
+            ]);
+            const present = new Set(models.map((m) => m.value.split("/")[0]));
+            const missing = [...expected].filter((id) => !present.has(id));
+            if (missing.length > 0) {
+              console.warn(
+                "[agent-manager] opencode provider drift — missing:",
+                missing,
+                "— restarting + refetching",
+              );
+              OpencodeProvider.restartServer();
+              await provider.dispose();
+              provider = createProvider(key as ProviderType);
+              await provider.initialize({
+                cliPath,
+                ...(opencodeConfig ? { opencodeConfig } : {}),
+              });
+              models = await provider.getAvailableModels();
+            }
             const enabled = getOpencodeEnabledModels();
             models = models.filter((m) => {
               const providerId = m.value.split("/")[0];

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -152,9 +152,6 @@ function AppInner(): React.ReactElement {
   const [showGitHubDialog, setShowGitHubDialog] = useState(false);
   const [showCodexDialog, setShowCodexDialog] = useState(false);
   const [showOpencodeDialog, setShowOpencodeDialog] = useState(false);
-  const [opencodeInitialAddId, setOpencodeInitialAddId] = useState<
-    string | undefined
-  >(undefined);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [showSchedulesDialog, setShowSchedulesDialog] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">("dark");
@@ -1026,10 +1023,7 @@ function AppInner(): React.ReactElement {
                         </span>
                       </button>
                       <button
-                        onClick={() => {
-                          setOpencodeInitialAddId(undefined);
-                          setShowOpencodeDialog(true);
-                        }}
+                        onClick={() => setShowOpencodeDialog(true)}
                         className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
                         title="Opencode settings"
                       >
@@ -1037,17 +1031,6 @@ function AppInner(): React.ReactElement {
                         <span className="text-[var(--text-muted)]">
                           Opencode
                         </span>
-                      </button>
-                      <button
-                        onClick={() => {
-                          setOpencodeInitialAddId("ollama");
-                          setShowOpencodeDialog(true);
-                        }}
-                        className="no-drag flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs transition-colors hover:bg-[var(--border)]"
-                        title="Ollama local models"
-                      >
-                        <div className="w-1.5 h-1.5 rounded-full bg-orange-500" />
-                        <span className="text-[var(--text-muted)]">Ollama</span>
                       </button>
                       <button
                         onClick={() => setShowGitHubDialog(true)}
@@ -1303,7 +1286,6 @@ function AppInner(): React.ReactElement {
         <OpencodeSettingsDialog
           isOpen={showOpencodeDialog}
           onClose={() => setShowOpencodeDialog(false)}
-          initialAddProviderId={opencodeInitialAddId}
         />
 
         {/* GitHub connect dialog */}

--- a/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
@@ -319,13 +319,17 @@ function ProviderRow({
 }: ProviderRowProps): React.ReactElement {
   return (
     <div
-      className="flex items-center gap-2 p-2 rounded-md bg-[var(--bg-surface)] border border-[var(--border)]"
+      className="flex items-center gap-3 px-3 py-2 rounded-md bg-[var(--bg-surface)] border border-[var(--border)]"
       data-testid={`opencode-row-${id}`}
     >
       <div
-        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-          enabled && modelCount > 0 ? "bg-green-500" : "bg-gray-500"
-        }`}
+        className="flex-shrink-0 rounded-full"
+        style={{
+          width: 6,
+          height: 6,
+          backgroundColor:
+            enabled && modelCount > 0 ? "#22c55e" : "var(--border)",
+        }}
       />
       <div className="flex-1 min-w-0">
         <p className="text-xs font-medium text-[var(--text-primary)] truncate">
@@ -337,34 +341,64 @@ function ProviderRow({
           {modelCount} model{modelCount === 1 ? "" : "s"}
         </p>
       </div>
-      <button
-        role="switch"
-        aria-checked={enabled}
-        aria-label={`${enabled ? "Disable" : "Enable"} ${label}`}
-        onClick={() => onToggle(!enabled)}
-        className={`w-8 h-4 rounded-full transition-colors flex-shrink-0 relative ${
-          enabled ? "bg-green-600" : "bg-[var(--border)]"
-        }`}
-      >
-        <span
-          className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
-            enabled ? "translate-x-4" : "translate-x-0.5"
-          }`}
-        />
-      </button>
+      <Toggle
+        enabled={enabled}
+        onToggle={onToggle}
+        ariaLabel={`${enabled ? "Disable" : "Enable"} ${label}`}
+      />
       <button
         onClick={onManage}
-        className="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0 px-1"
+        className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors flex-shrink-0"
       >
         Manage
       </button>
       <button
         onClick={onRemove}
-        className="text-[10px] text-[var(--text-muted)] hover:text-red-400 transition-colors flex-shrink-0 px-1"
+        className="text-[11px] text-[var(--text-muted)] hover:text-red-400 transition-colors flex-shrink-0"
       >
         Remove
       </button>
     </div>
+  );
+}
+
+function Toggle({
+  enabled,
+  onToggle,
+  ariaLabel,
+}: {
+  enabled: boolean;
+  onToggle: (next: boolean) => void;
+  ariaLabel: string;
+}): React.ReactElement {
+  const TRACK_W = 28;
+  const TRACK_H = 16;
+  const KNOB = 12;
+  const PAD = 2;
+  return (
+    <button
+      role="switch"
+      aria-checked={enabled}
+      aria-label={ariaLabel}
+      onClick={() => onToggle(!enabled)}
+      className="flex-shrink-0 relative rounded-full transition-colors p-0 border-0 cursor-pointer"
+      style={{
+        width: TRACK_W,
+        height: TRACK_H,
+        backgroundColor: enabled ? "#16a34a" : "var(--border)",
+      }}
+    >
+      <span
+        className="absolute rounded-full bg-white transition-all"
+        style={{
+          width: KNOB,
+          height: KNOB,
+          top: (TRACK_H - KNOB) / 2,
+          left: enabled ? TRACK_W - KNOB - PAD : PAD,
+          boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
+        }}
+      />
+    </button>
   );
 }
 

--- a/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/OpencodeSettingsDialog.tsx
@@ -446,9 +446,15 @@ function AddProviderPanel({
 
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [ollamaModels, setOllamaModels] = useState<OllamaModelInfo[]>([]);
-  const [selected, setSelected] = useState<Set<string>>(
-    new Set(existingSelection),
-  );
+  // Ollama rows toggle on bare model name (e.g. "gemma4:latest") while the
+  // stored selection uses fully-qualified values (e.g. "ollama/gemma4:latest").
+  // Strip the provider prefix so the checkbox reflects the saved state.
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    if (editing && fixedProviderId === "ollama") {
+      return new Set(existingSelection.map((v) => v.replace(/^ollama\//, "")));
+    }
+    return new Set(existingSelection);
+  });
   const [fetching, setFetching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      ollama:
+        specifier: ^0.6.3
+        version: 0.6.3
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -3355,6 +3358,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4199,6 +4205,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -7807,6 +7816,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -8715,6 +8728,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@3.0.0: {}
 


### PR DESCRIPTION
## Problem
If the opencode server dies, wedges, or is running with stale env (e.g. missing Ollama config), the user only finds out by trying to chat and getting silence. Recovery was manual: kill the process, restart the app.

## Fix — two self-healing layers

### 1. sendMessage health check (core)
Before starting a stream, probe \`/provider\` with a 2s timeout. If the server is unreachable, call \`recoverServer()\`:
- \`OpencodeProvider.restartServer(this.port)\` kills the registered proc (if any)
- Re-runs \`initialize()\` with the provider's current config, which spawns a fresh process with up-to-date env (the port-kill fix from #64 handles any external port holder)

After recovery, \`sendMessage\` proceeds normally. The health check only runs at the start of a stream — once events are flowing we can't safely retry.

### 2. Model-list drift detection (desktop)
In the \`GET_AVAILABLE_MODELS\` handler, compare the \`/provider\` response to what we have configured in settings (\`opencodeProviderKeys\` + \`ollamaConfig\`). If any expected sub-provider is missing from the response, the server is running with stale env — restart once and refetch before returning to the picker.

This is defense-in-depth against the exact symptom @ajayprakashmenon hit earlier today (Ollama models absent from picker after installing gemma4:26B).

## Test plan
- [x] Warmed opencode, killed process mid-session, sent another message — auto-recovered, response returned.
- [x] Log confirmed: \`recovering server on port X (restart + reinit)\` → \`restarting\` → \`starting\` → success.
- [x] \`pnpm --filter @stratosapp/desktop test\` — 93 tests pass.
- [x] Typecheck — no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)