### PR TITLE
feat(preview): add stratos-preview MCP so agents can open/close the side preview pane

### DIFF
--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -95,6 +95,7 @@ export const IPC_CHANNELS = {
   // Preview pane
   PREVIEW_OPEN_URL: "preview:open-url",
   PREVIEW_OPEN_MARKDOWN: "preview:open-markdown",
+  PREVIEW_CLOSE: "preview:close",
 
   // File explorer
   FILES_LIST_DIR: "files:list-dir",

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -48,6 +48,12 @@ import type { OllamaConfig, OllamaModelInfo } from "./settings/settings.store";
 import { resolveToolBehavior, effectiveToolName } from "./agent-session-logic";
 import { resolveClaudePathOrUndefined } from "./integrations/claude-path";
 import { getScheduleMcpPath } from "./scheduler/scheduler";
+import {
+  getPreviewMcpPath,
+  getPreviewSocketPath,
+  installPreviewMcp,
+  startPreviewSocketServer,
+} from "./preview-mcp";
 
 /**
  * Build explicit MCP servers for an agent session.
@@ -59,12 +65,20 @@ import { getScheduleMcpPath } from "./scheduler/scheduler";
  *   - chrome-devtools: worktree mode only, for cross-worktree CDP debugging.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function buildMcpServers(cwd: string): Record<string, any> {
+function buildMcpServers(
+  cwd: string,
+  previewSocketPath: string,
+): Record<string, any> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const servers: Record<string, any> = {
     "stratos-scheduler": {
       command: "node",
       args: [getScheduleMcpPath()],
+    },
+    "stratos-preview": {
+      command: "node",
+      args: [getPreviewMcpPath()],
+      env: { STRATOS_PREVIEW_SOCKET: previewSocketPath },
     },
   };
 
@@ -317,10 +331,19 @@ export class AgentManager {
   private lastPlanMarkdown: { content: string; title: string } | null = null;
   private previewFileWatchers = new Map<string, FSWatcher>();
   private cachedSlashCommands: { name: string; description?: string }[] = [];
+  private previewSocketPath: string;
 
   constructor(window: BrowserWindow, storage?: FileStorageAdapter) {
     this.window = window;
     this.storage = storage ?? new FileStorageAdapter();
+
+    // Install preview MCP and start its Unix socket server
+    installPreviewMcp();
+    this.previewSocketPath = getPreviewSocketPath(getWorktreeInfo().hash);
+    startPreviewSocketServer(this.previewSocketPath, (channel, data) => {
+      this.sendToRenderer(channel, data);
+    });
+
     this.registerIpc();
     this.detectOrphanedThreads().catch((err) => {
       safeLog(console.error, "[agent-manager] orphan detection failed:", err);
@@ -944,7 +967,7 @@ export class AgentManager {
             )
           : undefined;
       const threadCwd = thread.cwd ?? process.env.HOME!;
-      const mcpServers = buildMcpServers(threadCwd);
+      const mcpServers = buildMcpServers(threadCwd, this.previewSocketPath);
       await provider.initialize({
         ...(providerName === "claude-code"
           ? {
@@ -972,6 +995,12 @@ export class AgentManager {
                   `- \`schedule_enable\` / \`schedule_disable\` — toggle a schedule on/off without deleting it`,
                   `- \`schedule_folders\` — list available folders (id, name, path)`,
                   `Each schedule fires in a new Stratos thread. Use the folder or cwd argument to control which folder the thread appears in.`,
+                  ``,
+                  `# Preview Pane`,
+                  `You have access to the \`stratos-preview\` MCP to control the side preview pane:`,
+                  `- \`preview_open_file(file_path, title?)\` — open any file in the preview pane (markdown files render as formatted text, all other files open in a code editor). Always use absolute paths.`,
+                  `- \`preview_close()\` — close the preview pane.`,
+                  `Use this after creating or editing a file so the user can see the result immediately.`,
                 ].join("\n"),
               },
             }
@@ -1632,7 +1661,7 @@ export class AgentManager {
             )
           : undefined;
       const threadCwd = thread.cwd ?? process.env.HOME!;
-      const mcpServers = buildMcpServers(threadCwd);
+      const mcpServers = buildMcpServers(threadCwd, this.previewSocketPath);
       await provider.initialize({
         ...(providerName === "claude-code"
           ? {
@@ -1657,6 +1686,11 @@ export class AgentManager {
                   `- \`schedule_create\` — schedule a new prompt`,
                   `- \`schedule_list\` — list existing schedules`,
                   `- \`schedule_folders\` — list available folders`,
+                  ``,
+                  `# Preview Pane`,
+                  `You have access to the \`stratos-preview\` MCP to control the side preview pane:`,
+                  `- \`preview_open_file(file_path, title?)\` — open any file in the preview pane. Always use absolute paths.`,
+                  `- \`preview_close()\` — close the preview pane.`,
                 ].join("\n"),
               },
             }

--- a/packages/desktop/src/main/preview-mcp-source.ts
+++ b/packages/desktop/src/main/preview-mcp-source.ts
@@ -1,0 +1,182 @@
+/**
+ * Source for the self-contained `stratos-preview-mcp` stdio MCP server.
+ * Written to ~/.stratos/bin/stratos-preview-mcp on app startup.
+ * Injected into every agent session so agents can open/close the side preview pane.
+ *
+ * Uses only Node.js built-ins — no external dependencies.
+ * Protocol: newline-delimited JSON-RPC 2.0 over stdio (MCP stdio transport).
+ * Communicates with the Electron main process via a Unix domain socket at
+ * the path given by STRATOS_PREVIEW_SOCKET env var.
+ */
+
+export const PREVIEW_MCP_SOURCE = `#!/usr/bin/env node
+"use strict";
+
+const net = require("net");
+const readline = require("readline");
+
+const SOCKET_PATH = process.env.STRATOS_PREVIEW_SOCKET;
+
+// ── socket helpers ────────────────────────────────────────────────────────────
+
+function sendCommand(command) {
+  return new Promise((resolve, reject) => {
+    if (!SOCKET_PATH) {
+      reject(new Error("STRATOS_PREVIEW_SOCKET not configured"));
+      return;
+    }
+    const client = net.createConnection(SOCKET_PATH, () => {
+      client.write(JSON.stringify(command) + "\\n");
+    });
+    let buf = "";
+    client.on("data", (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\\n");
+      if (nl === -1) return;
+      client.destroy();
+      try { resolve(JSON.parse(buf.slice(0, nl))); }
+      catch { resolve({ ok: true }); }
+    });
+    client.on("error", reject);
+    client.setTimeout(5000, () => {
+      client.destroy();
+      reject(new Error("Preview socket timeout — is Stratos running?"));
+    });
+  });
+}
+
+// ── tool implementations ──────────────────────────────────────────────────────
+
+async function toolPreviewOpenFile(args) {
+  const { file_path, title } = args;
+  if (!file_path) return { isError: true, text: "file_path is required" };
+  try {
+    const result = await sendCommand({ command: "open", path: file_path, title });
+    if (!result.ok) return { isError: true, text: result.error || "Failed to open preview" };
+    return { text: "Preview opened: " + file_path };
+  } catch (err) {
+    return { isError: true, text: "Preview error: " + (err.message || String(err)) };
+  }
+}
+
+async function toolPreviewClose() {
+  try {
+    await sendCommand({ command: "close" });
+    return { text: "Preview closed" };
+  } catch (err) {
+    return { isError: true, text: "Preview error: " + (err.message || String(err)) };
+  }
+}
+
+// ── tool registry ─────────────────────────────────────────────────────────────
+
+const TOOLS = [
+  {
+    name: "preview_open_file",
+    description: "Open a file in the Stratos side preview pane. Markdown files (.md, .markdown) are rendered as formatted text; all other files open in a code editor. Always use absolute file paths.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Absolute path to the file to preview" },
+        title: { type: "string", description: "Optional display title (defaults to the filename)" },
+      },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "preview_close",
+    description: "Close the Stratos side preview pane.",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+// ── MCP JSON-RPC dispatch ─────────────────────────────────────────────────────
+
+function respond(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\\n");
+}
+
+async function handleRequest(req) {
+  const { id, method, params = {} } = req;
+
+  switch (method) {
+    case "initialize":
+      respond({
+        jsonrpc: "2.0", id,
+        result: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: "stratos-preview", version: "1.0.0" },
+        },
+      });
+      return;
+
+    case "notifications/initialized":
+      return;
+
+    case "ping":
+      respond({ jsonrpc: "2.0", id, result: {} });
+      return;
+
+    case "tools/list":
+      respond({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+      return;
+
+    case "tools/call": {
+      const { name, arguments: args = {} } = params;
+      let result;
+      try {
+        switch (name) {
+          case "preview_open_file": result = await toolPreviewOpenFile(args); break;
+          case "preview_close":     result = await toolPreviewClose();        break;
+          default:
+            respond({ jsonrpc: "2.0", id, error: { code: -32601, message: "Unknown tool: " + name } });
+            return;
+        }
+      } catch (err) {
+        respond({
+          jsonrpc: "2.0", id,
+          result: { content: [{ type: "text", text: "Error: " + (err.message || String(err)) }], isError: true },
+        });
+        return;
+      }
+      respond({
+        jsonrpc: "2.0", id,
+        result: {
+          content: [{ type: "text", text: result.text }],
+          ...(result.isError ? { isError: true } : {}),
+        },
+      });
+      return;
+    }
+
+    default:
+      if (id !== undefined && id !== null) {
+        respond({ jsonrpc: "2.0", id, error: { code: -32601, message: "Method not found: " + method } });
+      }
+  }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let req;
+  try {
+    req = JSON.parse(trimmed);
+  } catch {
+    respond({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+    return;
+  }
+  handleRequest(req).catch((err) => {
+    respond({ jsonrpc: "2.0", id: req?.id ?? null, error: { code: -32603, message: err.message || String(err) } });
+  });
+});
+
+rl.on("close", () => process.exit(0));
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+`;

--- a/packages/desktop/src/main/preview-mcp.ts
+++ b/packages/desktop/src/main/preview-mcp.ts
@@ -1,0 +1,129 @@
+import net from "net";
+import {
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  unlinkSync,
+} from "fs";
+import { promises as fsPromises } from "fs";
+import { join, basename, extname } from "path";
+import { homedir } from "os";
+import { IPC_CHANNELS } from "../common/ipc-channels";
+import { PREVIEW_MCP_SOURCE } from "./preview-mcp-source";
+
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown", ".mdx"]);
+
+export function getPreviewMcpPath(): string {
+  return join(homedir(), ".stratos", "bin", "stratos-preview-mcp");
+}
+
+export function getPreviewSocketPath(instanceHash: string): string {
+  return join(homedir(), ".stratos", `preview-${instanceHash}.sock`);
+}
+
+export function installPreviewMcp(): void {
+  const binDir = join(homedir(), ".stratos", "bin");
+  if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+  writeFileSync(getPreviewMcpPath(), PREVIEW_MCP_SOURCE, "utf-8");
+  chmodSync(getPreviewMcpPath(), 0o755);
+}
+
+type SendToRenderer = (channel: string, data: unknown) => void;
+
+export function startPreviewSocketServer(
+  socketPath: string,
+  sendToRenderer: SendToRenderer,
+): net.Server {
+  try {
+    unlinkSync(socketPath);
+  } catch {}
+
+  const server = net.createServer((socket) => {
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      handlePreviewCommand(line, socket, sendToRenderer).catch(() => {
+        replySocket(socket, { ok: false, error: "Internal error" });
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  server.listen(socketPath, () => {
+    console.log(`[preview-mcp] Socket listening at ${socketPath}`);
+  });
+
+  server.on("error", (err) => {
+    console.error("[preview-mcp] Socket server error:", err);
+  });
+
+  return server;
+}
+
+function replySocket(
+  socket: net.Socket,
+  result: { ok: boolean; error?: string },
+): void {
+  try {
+    socket.write(JSON.stringify(result) + "\n");
+    socket.end();
+  } catch {}
+}
+
+async function handlePreviewCommand(
+  line: string,
+  socket: net.Socket,
+  sendToRenderer: SendToRenderer,
+): Promise<void> {
+  let cmd: { command: string; path?: string; title?: string };
+  try {
+    cmd = JSON.parse(line);
+  } catch {
+    replySocket(socket, { ok: false, error: "Invalid JSON" });
+    return;
+  }
+
+  if (cmd.command === "close") {
+    sendToRenderer(IPC_CHANNELS.PREVIEW_CLOSE, {});
+    replySocket(socket, { ok: true });
+    return;
+  }
+
+  if (cmd.command === "open") {
+    const filePath = cmd.path;
+    if (!filePath) {
+      replySocket(socket, { ok: false, error: "path is required" });
+      return;
+    }
+
+    let content: string;
+    try {
+      content = await fsPromises.readFile(filePath, "utf-8");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      replySocket(socket, { ok: false, error: `Cannot read file: ${msg}` });
+      return;
+    }
+
+    const fileName = cmd.title ?? basename(filePath);
+    const ext = extname(filePath).toLowerCase();
+    const isMarkdown = MARKDOWN_EXTENSIONS.has(ext);
+
+    sendToRenderer(
+      IPC_CHANNELS.PREVIEW_OPEN_MARKDOWN,
+      isMarkdown
+        ? { content, title: fileName }
+        : { content, title: fileName, filePath },
+    );
+
+    replySocket(socket, { ok: true });
+    return;
+  }
+
+  replySocket(socket, { ok: false, error: `Unknown command: ${cmd.command}` });
+}

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -373,6 +373,10 @@ const api = {
     );
   },
 
+  onPreviewClose: (callback: () => void): void => {
+    ipcRenderer.on(IPC_CHANNELS.PREVIEW_CLOSE, () => callback());
+  },
+
   // File explorer
   filesListDir: (
     dirPath: string,

--- a/packages/desktop/src/renderer/hooks/usePreview.ts
+++ b/packages/desktop/src/renderer/hooks/usePreview.ts
@@ -87,7 +87,8 @@ export function usePreview(activeThreadId?: string | null) {
         }
       },
     );
-  }, [openUrl, openMarkdown, openArtifactEditor]);
+    window.api.onPreviewClose(close);
+  }, [openUrl, openMarkdown, openArtifactEditor, close]);
 
   return {
     preview,


### PR DESCRIPTION
## Summary

- Agents can now call `preview_open_file(file_path, title?)` to show any file in the side preview pane — `.md`/`.markdown`/`.mdx` renders as formatted markdown, all other extensions open in the Monaco code editor
- Agents can call `preview_close()` to dismiss the pane
- No HTTP server, no new processes — uses a lightweight Unix domain socket that the Electron main process listens on; the MCP child connects per-call and disconnects immediately

## Implementation

- `preview-mcp-source.ts` — self-contained stdio MCP server script (same pattern as `stratos-scheduler`), installed to `~/.stratos/bin/stratos-preview-mcp` on startup
- `preview-mcp.ts` — installs the script and starts the Unix socket server inside `AgentManager` constructor
- `stratos-preview` MCP injected into every agent session via `buildMcpServers()` with `STRATOS_PREVIEW_SOCKET` env var
- System prompt updated to document both tools
- `PREVIEW_CLOSE` IPC channel wired through preload → `usePreview`

## Test plan

- [x] `preview_open_file` on `.md` file → rendered markdown in preview pane
- [x] `preview_close` → preview pane closes
- [x] `preview_open_file` on `.ts` file → Monaco editor with syntax highlighting
- [x] All 116 existing tests pass
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)