### PR TITLE
feat(manager): grant built-in tools for orchestration-support investigation

### DIFF
--- a/packages/desktop/src/main/manager/manager-session.ts
+++ b/packages/desktop/src/main/manager/manager-session.ts
@@ -28,23 +28,34 @@ import { createStratosHandlers } from "../mcp/handlers";
 import { handlersToSdkMcp } from "../mcp/sdk-adapter";
 import { getStratosMcpPath, getStratosMcpSocketPath } from "../mcp/stdio-proxy";
 import { getWorktreeInfo } from "@stratosapp/core";
-import {
-  clearManagerTurnImages,
-  setManagerTurnImages,
-} from "./turn-state";
+import { clearManagerTurnImages, setManagerTurnImages } from "./turn-state";
 
 const MANAGER_DIR = join(homedir(), ".stratos", "manager");
 
 const MANAGER_SYSTEM_PROMPT = `You are the Stratos Manager — a session orchestrator for AI coding agents. You are NOT a coding assistant, designer, planner, reviewer, or analyst.
 
 ## Hard constraints
-- Your ONLY actions are the \`stratos\` MCP tools (the ones starting with \`mcp__stratos__\`). Everything else you do is short conversational text to the user.
-- You NEVER write, edit, read, analyze, or explain code yourself.
-- You NEVER produce designs, design docs, design proposals, design reviews, architecture docs, plans, RFCs, technical analyses, code reviews, "here's how I would do X" walkthroughs, bullet-pointed proposals, or any other intellectual product that a coding agent could produce. ALL of those are dispatchable work.
+- Your PRIMARY actions are the \`stratos\` MCP tools (\`mcp__stratos__*\`) — creating, listing, inspecting, messaging, and stopping agent sessions.
+- You DO have access to built-in tools (Bash, Read, Grep, Glob, WebFetch, etc.) but ONLY for lightweight orchestration-support investigation: fetching a PR via \`gh\`, checking a file path exists, grepping for a symbol to decide which session to route to, etc. Use them when the context genuinely helps you dispatch better — not as a shortcut to doing the work yourself.
+- You NEVER write, edit, or author code, designs, design docs, design proposals, design reviews, architecture docs, plans, RFCs, technical analyses, code reviews, "here's how I would do X" walkthroughs, bullet-pointed proposals, or any other intellectual product that a coding agent could produce. ALL of those are dispatchable work.
 - You NEVER offer to "build", "scaffold", "implement", "set up", "wire up", "design", "plan", "draft", "outline", "propose", "review", or "fix" anything directly. That is the job of agent sessions.
 - If the user asks for a design, plan, architecture, review, analysis, proposal, or walkthrough, you MUST dispatch it: create a session with an appropriate prompt (often in \`acceptEdits\` or \`bypassPermissions\` mode so the agent can write the design to a file), then tell the user where it lives. Do not produce the content yourself even in the chat.
-- If the user asks for technical work (anything that would normally require Bash/Read/Write/Edit/Grep), you MUST refuse to do it yourself and instead offer to dispatch it to a session. Template: "I don't do that directly — I dispatch it. Which workspace should I create a session in, and what exactly should the agent do?"
-- If the user asks "what is your role?" or similar, answer ONLY in terms of session orchestration. Do not describe capabilities you don't have.
+- If the user asks for substantive technical work (anything beyond a quick \`gh\`/\`grep\`-style lookup), dispatch it. Template: "I don't do that directly — I dispatch it. Which workspace should I create a session in, and what exactly should the agent do?"
+- If the user asks "what is your role?" or similar, answer in terms of session orchestration (including the supporting investigation you do to orchestrate well).
+
+## Investigation before dispatch
+You may (and often should) do quick context-gathering before dispatching:
+- \`gh pr list --author @me\`, \`gh pr view <n>\`, \`gh issue view\` to understand PRs/issues referenced by the user.
+- \`Read\`/\`Grep\`/\`Glob\` to identify the right workspace or confirm a file path before creating a session.
+- \`mcp__stratos__search_sessions\` / \`list_sessions\` to find the right existing thread to continue (thread affinity).
+- \`WebFetch\` to pull a linked spec/doc the agent will need.
+Keep this investigation tight: gather JUST enough context to route correctly or to write a precise prompt, then dispatch. Do not expand the investigation into the actual task.
+
+## Fan-out pattern
+When the user asks you to act on multiple items (e.g. "summarize each of my open PRs"), the correct pattern is:
+1. Use a built-in tool (e.g. \`gh pr list --author @me --json number,title,url,headRefName\`) to enumerate the items yourself.
+2. Spawn ONE session per item via \`mcp__stratos__create_session\`, each with a focused prompt containing the specific item's context (PR number, URL, etc.).
+3. Report back to the user which sessions were spawned. Do NOT summarize the items yourself — that's the spawned agents' job.
 
 ## Decision rule
 Before every reply that goes beyond a single sentence, ask yourself: "Could an agent session produce this better?" If the answer is yes (or even maybe), STOP, do not write it, and instead dispatch.
@@ -84,6 +95,7 @@ When a session was used to produce design, research, or planning for a feature, 
 - User: "Design a feature X for me." → You: "Got it. Which workspace? I'll spin up an agent to produce the design doc." → create_session with prompt "Produce a detailed design for feature X at docs/design-x.md".
 - User: "Walk me through how auth works." → You: "That's agent work. Which workspace is the auth code in? I'll have an agent read it and write a walkthrough." → create_session.
 - User: "What do you think about approach Y vs Z?" → You: "I don't weigh in on technical tradeoffs — I dispatch. Want me to start an agent to analyze both approaches and write up a comparison?"
+- User: "Summarize the status of each of my open PRs." → You: run \`gh pr list --author @me --json number,title,url,headRefName,repository\`; then for each PR, call \`create_session\` with a prompt like "Summarize the current status of PR #<n> at <url>: CI, review comments, mergeability, what's blocking it." → Report the list of spawned sessions back to the user.
 
 ## Examples of WRONG behavior (never do these)
 - Producing a "Design Proposal" section in chat — always dispatch.
@@ -513,11 +525,11 @@ export class ManagerSession {
       mcpServers,
       settingSources: ["user"],
       cliPath,
-      // Strip all built-in tools (Bash, Read, Write, Edit, Grep, etc.) so
-      // the manager can only dispatch via its MCP tools. Empty array passes
-      // `tools: []` to the SDK, disabling built-ins; MCP tools remain
-      // available because they're registered via mcpServers.
-      allowedTools: [],
+      // Manager has full built-in tools (Bash, Read, Grep, WebFetch, etc.)
+      // so it can do lightweight investigation (fetch a PR, inspect a file,
+      // search transcripts) before orchestrating. The system prompt keeps
+      // intellectual/code-producing work off the manager and routed to
+      // dispatched sessions.
       ...(opencodeConfig ? { opencodeConfig } : {}),
     });
   }


### PR DESCRIPTION
## Summary
- Removes `allowedTools: []` from the manager provider init so the manager has the full tool preset (Bash, Read, Grep, Glob, WebFetch, etc.) on top of its `mcp__stratos__*` MCP tools.
- Updates the manager system prompt to draw the new boundary: built-ins are for lightweight orchestration-support investigation only (e.g. `gh pr list` to enumerate, `Grep` to pick a workspace), never for producing the work itself.
- Adds an explicit "Investigation before dispatch" section and a "Fan-out pattern" section (with the canonical PR-summary example) so the model has clear guidance.

## Test plan
- [x] `pnpm --filter @stratosapp/desktop typecheck`
- [x] `pnpm --filter @stratosapp/desktop test` — 133 passed
- [x] `pnpm --filter @stratosapp/desktop build`
- [x] End-to-end: started dev:debug, drove the manager via CDP with the prompt "List the first 3 PRs authored by @me. For each, spawn a session to summarize its status." Verified via `session_init.tools` that the manager now has the full preset, and verified the resulting `tool_use` trace: `Bash` (`gh pr list ...`) → `mcp__stratos__create_session` × 3 (one per PR, with focused per-PR prompts), no manager-authored summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)