### PR TITLE
feat(scheduler): notify Manager on every run + opt-in routeToManager dispatch

### DIFF
--- a/docs/schedules-through-manager.md
+++ b/docs/schedules-through-manager.md
@@ -1,0 +1,356 @@
+# Schedules → Manager: Design Document
+
+## Chosen Approach: Option A + Option B
+
+- **Option A (all schedules)**: Manager is notified when any schedule completes.
+  No routing, no bottleneck — pure visibility. Failures trigger a real Manager LLM
+  turn; successes are recorded as lightweight metadata.
+- **Option B (opt-in, agent-authored only)**: A `routeToManager: boolean` flag on
+  `ScheduledPrompt`. When true, execution is posted to the Manager at fire time.
+  This flag is intended for schedules created by the Manager or other agents, not
+  for human-created automations.
+
+Human-created schedules stay deterministic and independent. Agent-created schedules
+that need Manager intelligence opt in explicitly.
+
+---
+
+## Current Architecture (Baseline)
+
+### Schedules (direct path)
+
+```
+node-cron / setTimeout fires
+  → SchedulerManager.executePrompt()
+  → storage.createThread()
+  → agentManager.runScheduledPrompt()   # fire-and-forget, bypassPermissions
+  → on completion: update ScheduledPrompt status, show desktop notification
+```
+
+### Manager (orchestration path)
+
+```
+User / WhatsApp / child-completion
+  → ManagerSession.send()               # singleton LLM call
+  → Manager LLM decides what to do
+  → calls create_session MCP tool
+  → agentManager.startStream()
+  → on child completion: handleChildCompletion() notifies Manager
+```
+
+### Current Integration
+
+None. Completely independent codepaths sharing only the `AgentManager` runner.
+
+---
+
+## Notification Design (Option A)
+
+### Two-tier model
+
+Not all notifications should trigger a Manager LLM turn. That adds to Manager's
+conversation history, costs tokens, and makes Manager "busy" processing noise.
+
+| Event                               | Action                                                     |
+| ----------------------------------- | ---------------------------------------------------------- |
+| Schedule starts                     | UI metadata only — store start time, show status indicator |
+| Schedule completes (success)        | Lightweight metadata record; no LLM turn                   |
+| Schedule completes (failure)        | Full Manager LLM turn — error needs a decision             |
+| Schedule completes (routeToManager) | Full Manager LLM turn — Manager owns this result           |
+
+### Why not LLM turn for every completion?
+
+5 daily schedules × 2 (start + end) = 10 extra Manager LLM calls/day. Over a
+month: 300 additional interactions in Manager's context. This degrades reasoning
+quality and inflates cost with no user benefit for successful automations.
+
+### Agent-authored completion report
+
+The child agent can call `schedule_report` during its run to deposit a summary
+and metadata. This is the only thing the tool does — it stores data, triggers
+nothing. The scheduler always sends a notification to Manager when the run
+finishes, using whatever the agent deposited. If the agent never called the tool,
+the notification goes out anyway with basic metadata only.
+
+**`schedule_report` MCP tool** (called by the child agent at end of run):
+
+```typescript
+schedule_report({
+  scheduleId: string, // injected into prompt so agent knows it
+  summary: string, // 1-3 sentences: what was done, found, or changed
+});
+```
+
+No `status` or `errorMessage` on the tool — the agent only provides the summary.
+The scheduler determines final status from the run outcome.
+
+**Stored record format** (written by the tool, read by the scheduler on completion):
+
+```typescript
+{
+  scheduleId: string,
+  summary: string,          // agent-authored
+  depositedAt: number,
+}
+```
+
+### How the agent knows to call it
+
+The scheduler injects a postscript into every scheduled prompt before execution:
+
+```
+---
+[SCHEDULED TASK — {name}]
+Schedule ID: {scheduleId}
+Workspace: {folder}
+Provider: {provider}
+
+When you finish, call schedule_report with scheduleId="{id}" and a concise
+1-3 sentence summary of what you accomplished, found, or changed.
+```
+
+### Notification to Manager (always sent by scheduler)
+
+When a scheduled run completes — regardless of whether the agent called
+`schedule_report` — the scheduler sends a notification to Manager. The record
+format:
+
+```typescript
+{
+  type: "schedule_run",
+  scheduleId: string,
+  scheduleName: string,
+  threadId: string,
+  workspace: string,
+  provider: string,
+  status: "completed" | "error",
+  summary?: string,         // present if agent called schedule_report
+  durationMs: number,
+  errorMessage?: string,    // present if status === "error"
+  completedAt: number,
+}
+```
+
+**Notification weight by outcome:**
+
+| Outcome                        | Manager notification                           |
+| ------------------------------ | ---------------------------------------------- |
+| Completed, agent filed summary | Lightweight record — no LLM turn               |
+| Completed, no summary filed    | Lightweight record — no LLM turn               |
+| Error                          | Full Manager LLM turn — error needs a decision |
+
+The lightweight record is stored on Manager's thread without triggering `send()`.
+Manager can query it ("what ran today?", "what did the PR review find last Monday?")
+without it ever polluting the live conversation. Failures always trigger a real
+LLM turn because they may require action.
+
+**Failure LLM turn format:**
+
+```
+[SCHEDULE FAILURE] "{name}" failed after {duration}s
+Error: {errorMessage}
+Thread: {threadId}
+Schedule ID: {scheduleId}
+Workspace: {folder}
+Summary: {summary if filed, else "agent did not file a report"}
+```
+
+---
+
+## Opt-In Routing Design (Option B)
+
+### Who sets `routeToManager: true`?
+
+Only agents — specifically the Manager and any agent with access to `schedule_create`
+MCP tool. The UI schedule creation form does NOT expose this toggle. This enforces
+the intent: human-written automations are deterministic; agent-authored automations
+can be intelligent.
+
+### Self-describing prompt requirement
+
+When an agent creates a schedule with `routeToManager: true`, the `prompt` field
+MUST be fully self-contained. When the schedule fires (potentially weeks later),
+the Manager's conversation history from the creation session is gone. The prompt
+cannot reference prior context implicitly.
+
+The `schedule_create` MCP tool description should enforce this:
+
+> When routeToManager is true, the prompt must be fully self-describing — include
+> all relevant context, goals, and constraints inline. Do not reference "earlier
+> discussion" or "the analysis above."
+
+### Execution flow when `routeToManager: true`
+
+```
+node-cron / setTimeout fires
+  → SchedulerManager.executePrompt()
+  → prompt.routeToManager === true
+  → managerSession.sendFromScheduler(prompt, onComplete)
+    → Manager receives: "[SCHEDULED TASK] {name}\n{prompt}\nWorkspace: {folder}\nProvider: {provider}"
+    → Manager LLM: check list_sessions for conflicts, then create_session
+    → child thread runs with spawnedBy: "manager", scheduledPromptId: {id}
+    → on child completion: handleChildCompletion() detects scheduledPromptId
+    → calls registered onComplete(status)
+  → SchedulerManager.onComplete:
+    → update ScheduledPrompt.lastRunStatus / lastRunAt
+    → disable one-time schedules
+    → show desktop notification
+```
+
+The scheduler still owns status lifecycle — `onComplete` callback bridges Manager
+execution back to scheduler bookkeeping.
+
+### Manager system prompt addition
+
+```
+## Scheduled Task Dispatch
+
+When you receive a message prefixed with [SCHEDULED TASK]:
+1. DO NOT modify or summarize the task prompt — pass it verbatim to create_session
+2. Check list_sessions for any running session doing the same work
+3. If a conflict exists: report it; do not spawn a duplicate
+4. Create the session with the specified provider and workspace
+5. Reply with the spawned threadId only — no commentary
+```
+
+This narrows LLM non-determinism for schedule dispatch: the Manager becomes a
+smart router, not a rewriter.
+
+---
+
+## Manager as Schedule Author (Option C, included)
+
+Manager gains `schedule_create` and `schedule_list` in its MCP tool set. This
+allows conversations like:
+
+> "Run a PR review summary every Monday at 9am and send it to WhatsApp"
+
+Manager creates the schedule with `routeToManager: true` and a self-describing
+prompt. When it fires, execution comes back through Manager, which has the WhatsApp
+forwarding capability.
+
+This is the natural end-to-end use case that makes `routeToManager` valuable.
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Data Model
+
+**`packages/core/src/types/scheduled-prompt.ts`**
+
+- Add `routeToManager?: boolean` to `ScheduledPrompt`
+- No migration needed — undefined === false
+
+### Phase 2 — Schedule Report MCP Tool + Notification (Option A)
+
+**`packages/desktop/src/main/mcp/handlers/scheduler.ts`**
+
+- Add `schedule_report(scheduleId, summary)` MCP tool
+- On call: store `{ scheduleId, summary, depositedAt }` in a transient in-memory
+  map (keyed by `scheduleId`) — no Manager interaction, no side effects
+- The scheduler reads from this map when the run finishes
+
+**`packages/desktop/src/main/scheduler/scheduler.ts`**
+
+- Before calling `agentManager.runScheduledPrompt()`, prepend the postscript
+  to the prompt:
+  ```
+  ---
+  [SCHEDULED TASK — {name}]
+  Schedule ID: {scheduleId}
+  Workspace: {folder}
+  When you finish, call schedule_report with scheduleId="{id}" and a concise summary.
+  ```
+- After run completes (success or error): build a `ScheduleRunRecord` — check
+  the in-memory map for an agent-filed summary, include it if present
+- Call `managerSession.recordScheduleRun(record)` unconditionally
+- If the run errored: additionally call `managerSession.reportScheduleFailure(record)`
+  to trigger a Manager LLM turn
+- Clear the in-memory summary entry after consuming it
+
+**`packages/desktop/src/main/manager/manager-session.ts`**
+
+- Add `recordScheduleRun(record: ScheduleRunRecord)` — writes record to Manager
+  thread storage without triggering `send()`
+- Add `reportScheduleFailure(record: ScheduleRunRecord)` — calls `send()` with
+  the `[SCHEDULE FAILURE]` directive
+
+### Phase 3 — ManagerSession: Scheduler Entry Point (Option B)
+
+**`packages/desktop/src/main/manager/manager-session.ts`**
+
+- Add `sendFromScheduler(prompt: ScheduledPrompt, onComplete: (status: "completed" | "error") => void)`
+- Distinct from `sendFromGateway` — carries schedule metadata in message prefix
+- Registers `onComplete` keyed by `prompt.id` in a `Map<string, callback>`
+- Extend `handleChildCompletion()`: if completed thread has `scheduledPromptId`,
+  look up and call the registered callback, then delete it from the map
+
+### Phase 4 — Scheduler: Routing Fork (Option B)
+
+**`packages/desktop/src/main/scheduler/scheduler.ts`**
+
+- `SchedulerManager` constructor receives `managerSession: ManagerSession` reference
+  (injected in `main/index.ts` after both are initialized)
+- In `executePrompt()`:
+  - If `!prompt.routeToManager`: existing path unchanged
+  - If `prompt.routeToManager`: skip `createThread` + `runScheduledPrompt`; call
+    `managerSession.sendFromScheduler(prompt, statusCallback)`
+- Status callback updates `ScheduledPrompt` record and disables one-time schedules
+
+### Phase 5 — Manager MCP: Schedule Tools (Option C)
+
+**`packages/desktop/src/main/mcp/handlers/manager.ts`**
+
+- Add `schedule_create` tool (thin wrapper over existing `SchedulerManager.create()`)
+- Add `schedule_list` tool (wrapper over `SchedulerManager.list()`)
+- Add `schedule_disable` / `schedule_enable` tools
+- Update Manager system prompt to document these tools and the self-describing
+  prompt requirement for `routeToManager: true`
+
+**`packages/desktop/src/main/manager/manager-session.ts`**
+
+- Pass `schedulerManager` reference into the MCP handler so schedule tools can
+  call it
+
+### Phase 6 — Wiring in `main/index.ts`
+
+- `SchedulerManager` receives `managerSession` after both are initialized
+- `ManagerSession` MCP handler receives `schedulerManager` reference
+- Initialization order: `storage` → `agentManager` → `schedulerManager` (no
+  manager dep yet) → `managerSession` → inject `managerSession` into
+  `schedulerManager`
+
+### Phase 7 — Manager System Prompt
+
+Update `manager-session.ts` system prompt:
+
+- Add "Scheduled Task Dispatch" section (see above)
+- Add "Schedule Authoring" section documenting `schedule_create` tool and the
+  self-describing prompt rule
+- Add "Schedule Awareness" section noting Manager can call `schedule_list` to
+  check what automations exist before making decisions
+
+---
+
+## Resolved Design Decisions
+
+| Question                                | Decision                                                                                                 |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| LLM turn for every schedule completion? | No — only failures and `routeToManager` completions; successes stored as agent-authored metadata records |
+| `routeToManager` default                | `false` — opt-in only                                                                                    |
+| Who can set `routeToManager: true`?     | Agents only (via MCP); not exposed in UI form                                                            |
+| Manager busy when schedule fires?       | Queue it (existing `notificationQueue` mechanism)                                                        |
+| Prompt self-containment enforcement     | MCP tool description + system prompt instruction                                                         |
+| Start notifications                     | UI metadata only, no LLM turn                                                                            |
+| Schedule authoring by Manager           | Yes, via new schedule tools in manager MCP handler                                                       |
+
+---
+
+## What Does NOT Change
+
+- Human-created schedules: identical behavior — deterministic, direct, no Manager hop
+- Permission model: all scheduled threads still run `bypassPermissions`
+- Scheduler lifecycle ownership: `lastRunStatus`, `lastRunAt`, one-time disabling
+  remain scheduler responsibilities (callback pattern bridges Manager execution)
+- Manager singleton constraint: no parallel streams introduced

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ScheduleConfig,
   ScheduleType,
   RecurringInterval,
+  ScheduleRunRecord,
 } from "./types/scheduled-prompt";
 export { scheduleToCron, scheduleToHuman } from "./types/scheduled-prompt";
 export { normalizeMode } from "./types/thread";
@@ -70,6 +71,11 @@ export {
   deleteScheduledPrompt,
   getScheduledPrompt,
 } from "./storage/scheduled-prompts.store";
+export {
+  loadScheduleRuns,
+  appendScheduleRun,
+  listScheduleRuns,
+} from "./storage/schedule-runs.store";
 
 // Utils
 export type { WorktreeInfo } from "./utils/worktree";

--- a/packages/core/src/storage/schedule-runs.store.ts
+++ b/packages/core/src/storage/schedule-runs.store.ts
@@ -1,0 +1,62 @@
+/**
+ * Persistent log of scheduled-prompt run completions. Used by the Manager as
+ * a lightweight situational-awareness record — entries do NOT trigger Manager
+ * LLM turns, so successful runs accumulate here without polluting Manager's
+ * conversation history. Failures still trigger a real LLM turn (separate
+ * mechanism in ManagerSession) but a record is appended here too.
+ *
+ * The file is capped at MAX_RECORDS to bound disk and read costs. Oldest
+ * entries are dropped first.
+ */
+import { join } from "path";
+import { homedir } from "os";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import type { ScheduleRunRecord } from "../types/scheduled-prompt";
+
+const STORE_FILE = "schedule-runs.json";
+const MAX_RECORDS = 500;
+
+function getStorePath(): string {
+  const dir = join(homedir(), ".stratos", "manager");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return join(dir, STORE_FILE);
+}
+
+export function loadScheduleRuns(): ScheduleRunRecord[] {
+  const path = getStorePath();
+  if (!existsSync(path)) return [];
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw) as ScheduleRunRecord[];
+  } catch {
+    return [];
+  }
+}
+
+export function appendScheduleRun(record: ScheduleRunRecord): void {
+  const records = loadScheduleRuns();
+  records.push(record);
+  // Keep newest MAX_RECORDS.
+  const trimmed =
+    records.length > MAX_RECORDS
+      ? records.slice(records.length - MAX_RECORDS)
+      : records;
+  writeFileSync(getStorePath(), JSON.stringify(trimmed, null, 2), "utf-8");
+}
+
+/**
+ * Read recent schedule runs, newest first, capped at limit.
+ * Optionally filter to a single scheduleId.
+ */
+export function listScheduleRuns(opts?: {
+  limit?: number;
+  scheduleId?: string;
+}): ScheduleRunRecord[] {
+  const records = loadScheduleRuns();
+  let filtered = opts?.scheduleId
+    ? records.filter((r) => r.scheduleId === opts.scheduleId)
+    : records;
+  filtered = filtered.slice().reverse();
+  if (opts?.limit && opts.limit > 0) filtered = filtered.slice(0, opts.limit);
+  return filtered;
+}

--- a/packages/core/src/types/scheduled-prompt.ts
+++ b/packages/core/src/types/scheduled-prompt.ts
@@ -38,6 +38,40 @@ export interface ScheduledPrompt {
   lastRunAt?: number;
   lastRunThreadId?: string;
   lastRunStatus?: "running" | "completed" | "error";
+  /**
+   * When true, the schedule fires by posting to the Manager agent instead of
+   * running the prompt directly. The Manager decides how to dispatch — useful
+   * for agent-authored schedules that need orchestration intelligence
+   * (batching, conflict checks, contextual rewriting).
+   *
+   * Set this only via the schedule_create MCP tool — the UI form does not
+   * expose it. Prompts with routeToManager must be fully self-describing
+   * since Manager's conversation history from creation time will be gone
+   * by the time the schedule fires.
+   */
+  routeToManager?: boolean;
+}
+
+/**
+ * Record the scheduler emits to the Manager when a scheduled run completes.
+ * Combines run metadata with an optional agent-authored summary deposited via
+ * the `schedule_report` MCP tool. The notification is unconditional — if the
+ * agent did not call schedule_report, `summary` is omitted but the record is
+ * still sent.
+ */
+export interface ScheduleRunRecord {
+  scheduleId: string;
+  scheduleName: string;
+  threadId: string;
+  workspace: string;
+  provider: ProviderType;
+  status: "completed" | "error";
+  /** Agent-authored 1-3 sentence summary; absent if schedule_report wasn't called */
+  summary?: string;
+  durationMs: number;
+  errorMessage?: string;
+  startedAt: number;
+  completedAt: number;
 }
 
 /** Convert a friendly ScheduleConfig to a cron expression for node-cron. */

--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -161,6 +161,8 @@ export const IPC_CHANNELS = {
   MANAGER_INTERRUPT: "manager:interrupt",
   MANAGER_THREAD_ID: "manager:thread-id",
   MANAGER_SWITCH_PROVIDER: "manager:switch-provider",
+  MANAGER_SCHEDULE_RUN_RECORDED: "manager:schedule-run-recorded",
+  MANAGER_SCHEDULE_RUNS: "manager:schedule-runs",
 
   // WhatsApp gateway
   WHATSAPP_GET_STATE: "whatsapp:get-state",

--- a/packages/desktop/src/main/__tests__/handlers-scheduler.test.ts
+++ b/packages/desktop/src/main/__tests__/handlers-scheduler.test.ts
@@ -45,7 +45,7 @@ describe("scheduler handlers", () => {
     if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("produces exactly 6 tools with the expected names", () => {
+  it("produces exactly 8 tools with the expected names", () => {
     const defs = createSchedulerHandlers({ storage: makeStorage([]) });
     expect(defs.map((d) => d.name).sort()).toEqual([
       "schedule_create",
@@ -54,6 +54,8 @@ describe("scheduler handlers", () => {
       "schedule_enable",
       "schedule_folders",
       "schedule_list",
+      "schedule_report",
+      "schedule_runs",
     ]);
   });
 

--- a/packages/desktop/src/main/__tests__/mcp-parity.test.ts
+++ b/packages/desktop/src/main/__tests__/mcp-parity.test.ts
@@ -110,7 +110,7 @@ describe("cross-transport parity: SDK adapter vs socket MCP server", () => {
       sock.end();
 
       expect(socketNames).toEqual(sdkNames);
-      expect(socketNames).toHaveLength(20);
+      expect(socketNames).toHaveLength(22);
     } finally {
       await server.close();
     }

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -950,12 +950,16 @@ export class AgentManager {
         const worktreeDir = join(homedir(), ".stratos", "worktrees", threadId);
         mkdirSync(worktreeDir, { recursive: true });
 
-        execFileSync("git", ["worktree", "add", "-b", branchName, worktreeDir], {
-          cwd: thread.cwd,
-          encoding: "utf-8",
-          timeout: 30000,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        execFileSync(
+          "git",
+          ["worktree", "add", "-b", branchName, worktreeDir],
+          {
+            cwd: thread.cwd,
+            encoding: "utf-8",
+            timeout: 30000,
+            stdio: ["pipe", "pipe", "pipe"],
+          },
+        );
 
         await this.storage.updateThread(threadId, {
           worktree: {
@@ -1779,6 +1783,7 @@ export class AgentManager {
                   `# Stratos MCP`,
                   `The \`stratos\` MCP server exposes:`,
                   `- \`schedule_create\`, \`schedule_list\`, \`schedule_folders\` — manage scheduled prompts`,
+                  `- \`schedule_report\` — call this at the end of your run with a 1-3 sentence summary of what you did. Look for a [SCHEDULED TASK] context block in your prompt with the scheduleId. Your summary is forwarded to the Manager as a status update.`,
                   `- \`preview_open_file(file_path, title?)\` / \`preview_close()\` — control the side preview pane (use absolute paths)`,
                 ].join("\n"),
               },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -285,6 +285,12 @@ if (!gotLock) {
     agentManager.setManagerMcpStatusProvider(() =>
       managerSession!.getMcpServerStatus(),
     );
+
+    // Cross-wire scheduler ↔ manager. SchedulerManager needs ManagerSession to
+    // forward run notifications and to dispatch routeToManager schedules. The
+    // wiring is post-construction since ManagerSession is a singleton
+    // initialized after SchedulerManager.
+    schedulerManager.setManagerSession(managerSession);
   }
 
   app.on("web-contents-created", (_event, contents) => {

--- a/packages/desktop/src/main/manager/manager-session.ts
+++ b/packages/desktop/src/main/manager/manager-session.ts
@@ -14,12 +14,14 @@ import {
   createProvider,
   FileStorageAdapter,
   appendTraceEntry,
+  appendScheduleRun,
 } from "@stratosapp/core";
 import type {
   AgentProvider,
   AgentMessage,
   McpServerInfo,
   ProviderType,
+  ScheduleRunRecord,
 } from "@stratosapp/core";
 import { resolveClaudePathOrUndefined } from "../integrations/claude-path";
 import { loadSettings } from "../settings/settings.store";
@@ -67,6 +69,23 @@ Before every reply that goes beyond a single sentence, ask yourself: "Could an a
 - Relay messages between the user and sessions.
 - Summarize session transcripts when the user asks what an agent did.
 - Schedule recurring triggers via \`mcp__stratos__schedule_*\` when the user asks.
+- Query the log of past scheduled-prompt runs via \`mcp__stratos__schedule_runs\`.
+
+## Scheduled Task Dispatch
+When you receive a message prefixed with [SCHEDULED TASK], it means a routeToManager schedule fired and is asking you to dispatch the work. Follow this protocol exactly:
+1. DO NOT modify, summarize, or rewrite the task prompt — pass it verbatim to \`create_session\`.
+2. Briefly check \`list_sessions\` for any in-progress session doing the same work. If a clear conflict exists, DO NOT spawn a duplicate — reply with the existing threadId and skip dispatch.
+3. Otherwise, call \`create_session\` with workspace, provider, model, AND \`scheduledPromptId\` set to the Schedule ID from the context block. The scheduledPromptId is REQUIRED so the scheduler can track this run's status and summary. Pass the task prompt unchanged.
+4. Reply with the spawned threadId only, no commentary. Brevity matters — these notifications must not bloat your context.
+
+## Schedule Authoring (when the user asks you to create a schedule)
+- Use \`mcp__stratos__schedule_create\` to create scheduled prompts.
+- Default behavior is direct execution — the schedule fires, a thread is created, the prompt runs autonomously. Pick this for simple, deterministic tasks (run a script, check a URL, generate a daily report).
+- Set \`routeToManager: true\` ONLY when the work genuinely benefits from Manager intelligence — e.g., the schedule should check for in-progress related work before dispatching, batch with another schedule firing close in time, or contextually rewrite the prompt before execution. For ordinary cron-style automations, do NOT set this flag.
+- When you set \`routeToManager: true\`, the prompt MUST be fully self-describing. Include every relevant detail — workspace, goals, constraints, expected output format. By the time the schedule fires (potentially weeks later), your conversation history from creation time will be gone.
+
+## Scheduled Run Reports
+When a scheduled run completes, the agent that ran it may have called \`schedule_report\` to deposit a summary. The summary becomes part of the run record visible via \`schedule_runs\`. Failed scheduled runs are reported to you as a [SCHEDULE FAILURE] notification — when you receive one, decide whether to retry, alert the user, investigate the thread, or disable the schedule, then reply with a brief 1-2 sentence summary.
 
 ## Conversational relay
 - "Tell cosmic-fox to X" → call \`send_message\` with prompt exactly "X". Don't rephrase. Then tell the user it was sent.
@@ -124,6 +143,17 @@ export class ManagerSession {
   private completionUnsub?: () => void;
   private isNotificationInFlight = false;
   private notificationBackoffUntil = 0;
+
+  /**
+   * Pending callbacks for routeToManager: true schedules. Keyed by scheduleId.
+   * When a child thread with thread.scheduledPromptId === <id> completes, we
+   * invoke and clear the callback so the SchedulerManager can update its
+   * bookkeeping (lastRunStatus, one-time disable, etc.).
+   */
+  private schedulerCallbacks = new Map<
+    string,
+    (status: "completed" | "error", err?: string) => void
+  >();
 
   /**
    * "remote" — Manager replies and notifications are forwarded to WhatsApp.
@@ -512,6 +542,80 @@ export class ManagerSession {
     }
   }
 
+  /**
+   * Append a scheduled-run record to the persistent run log. Does NOT trigger
+   * a Manager LLM turn — the Manager only sees this entry if it explicitly
+   * queries the run log. Used for successful runs where no decision is
+   * required.
+   */
+  recordScheduleRun(record: ScheduleRunRecord): void {
+    try {
+      appendScheduleRun(record);
+    } catch (err) {
+      console.error("[manager-session] failed to record schedule run:", err);
+    }
+    // Notify the renderer so any UI surface can refresh.
+    this.sendToRenderer(IPC_CHANNELS.MANAGER_SCHEDULE_RUN_RECORDED, record);
+  }
+
+  /**
+   * Trigger a Manager LLM turn for a failed scheduled run. The Manager can
+   * then decide whether to retry, alert the user, investigate the thread, or
+   * disable the schedule. Queued via the standard notification queue so it
+   * waits if the Manager is mid-turn.
+   */
+  reportScheduleFailure(record: ScheduleRunRecord): void {
+    const summaryLine = record.summary
+      ? `Summary: ${record.summary}`
+      : "Summary: agent did not file a report";
+    const directive = [
+      `[SCHEDULE FAILURE] "${record.scheduleName}" failed after ${Math.round(record.durationMs / 1000)}s`,
+      `Schedule ID: ${record.scheduleId}`,
+      `Thread: ${record.threadId}`,
+      `Workspace: ${record.workspace}`,
+      `Provider: ${record.provider}`,
+      `Error: ${record.errorMessage ?? "(no error message)"}`,
+      summaryLine,
+      "",
+      "Decide whether to retry (run schedule_run_now), notify the user, investigate the thread (mcp__stratos__get_session with includeTranscript=true), or disable the schedule (mcp__stratos__schedule_disable). Reply with a brief 1-2 sentence summary of what happened and the action you took.",
+    ].join("\n");
+
+    this.notificationQueue.push({ prompt: directive });
+    this.drainNotificationQueue();
+  }
+
+  /**
+   * Dispatch a routeToManager: true scheduled prompt to the Manager. The
+   * Manager will receive the task and own its execution (typically by
+   * calling create_session). Caller registers an onComplete callback so
+   * the scheduler can update its bookkeeping when the spawned child finishes.
+   */
+  sendFromScheduler(
+    prompt: import("@stratosapp/core").ScheduledPrompt,
+    workspace: string,
+    onComplete: (status: "completed" | "error", err?: string) => void,
+  ): void {
+    // Register the callback against the scheduleId; handleChildCompletion
+    // looks it up when a thread with this scheduledPromptId completes.
+    this.schedulerCallbacks.set(prompt.id, onComplete);
+
+    const directive = [
+      `[SCHEDULED TASK — ${prompt.name}]`,
+      `Schedule ID: ${prompt.id}`,
+      `Workspace: ${workspace}`,
+      `Provider: ${prompt.provider}`,
+      ...(prompt.model ? [`Model: ${prompt.model}`] : []),
+      "",
+      "Task:",
+      prompt.prompt,
+      "",
+      "Dispatch this task: check list_sessions for any in-progress conflicting work, then call create_session with the workspace and provider above. Pass the task verbatim — do NOT rewrite or summarize it. Set the spawned thread's scheduledPromptId metadata so completion is tracked. Reply with the spawned threadId only.",
+    ].join("\n");
+
+    this.notificationQueue.push({ prompt: directive });
+    this.drainNotificationQueue();
+  }
+
   dispose(): void {
     this.completionUnsub?.();
     this.completionUnsub = undefined;
@@ -519,6 +623,7 @@ export class ManagerSession {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = undefined;
     }
+    this.schedulerCallbacks.clear();
     if (this.idleTimer) {
       clearTimeout(this.idleTimer);
       this.idleTimer = null;
@@ -548,6 +653,26 @@ export class ManagerSession {
       if (thread.lastReportedRunId === event.runId) return;
     } else {
       if (thread.reportedToManager) return;
+    }
+
+    // If this thread was spawned by Manager in response to a routeToManager
+    // schedule (carries a scheduledPromptId), invoke the registered scheduler
+    // callback so SchedulerManager can update bookkeeping. Skip the standard
+    // child-completion notification — the scheduler will emit its own
+    // scheduled-run record, which is the canonical channel for scheduled work.
+    if (thread.scheduledPromptId) {
+      const cb = this.schedulerCallbacks.get(thread.scheduledPromptId);
+      if (cb) {
+        this.schedulerCallbacks.delete(thread.scheduledPromptId);
+        const status: "completed" | "error" =
+          event.status === "completed" ? "completed" : "error";
+        try {
+          cb(status, event.errorMessage);
+        } catch (err) {
+          console.error("[manager-session] scheduler callback threw:", err);
+        }
+        return;
+      }
     }
 
     const title = thread.title?.trim() || event.threadId;

--- a/packages/desktop/src/main/mcp/handlers/manager.ts
+++ b/packages/desktop/src/main/mcp/handlers/manager.ts
@@ -5,10 +5,12 @@ import { z } from "zod";
 import type { BrowserWindow } from "electron";
 import type { AgentManager } from "../../agent-manager";
 import type { FileStorageAdapter, StoredMessage } from "@stratosapp/core";
+import { getScheduledPrompt } from "@stratosapp/core";
 import { IPC_CHANNELS } from "../../../common/ipc-channels";
 import { getManagerTurnImages } from "../../manager/turn-state";
 import { type HandlerDef, defineHandler, textResult } from "./types";
 import { getManagerRef } from "../../manager/manager-ref";
+import { decoratePromptWithSchedule } from "../../scheduler/decorate-prompt";
 
 const imagesSchema = z
   .array(
@@ -75,7 +77,7 @@ export function createManagerHandlers(deps: ManagerDeps): HandlerDef[] {
     defineHandler({
       name: "create_session",
       description:
-        "Start a new agent session in a workspace. Returns the thread ID immediately (non-blocking). Use get_session later to check status.",
+        "Start a new agent session in a workspace. Returns the thread ID immediately (non-blocking). Use get_session later to check status. When dispatching a [SCHEDULED TASK], pass the Schedule ID via the scheduledPromptId parameter so the run is tracked.",
       inputSchema: {
         workspace: z
           .string()
@@ -101,6 +103,12 @@ export function createManagerHandlers(deps: ManagerDeps): HandlerDef[] {
           .enum(["local", "worktree"])
           .optional()
           .describe("Git worktree isolation"),
+        scheduledPromptId: z
+          .string()
+          .optional()
+          .describe(
+            "When dispatching a [SCHEDULED TASK], pass the Schedule ID from the context block. Required for scheduler bookkeeping (lastRunStatus, summary record). Omit otherwise.",
+          ),
         images: imagesSchema,
       },
       handler: async (args) => {
@@ -122,6 +130,8 @@ export function createManagerHandlers(deps: ManagerDeps): HandlerDef[] {
             mode: args.mode ?? "bypassPermissions",
           };
           if (args.worktreeMode) updates.worktreeMode = args.worktreeMode;
+          if (args.scheduledPromptId)
+            updates.scheduledPromptId = args.scheduledPromptId;
           storage.updateThread(thread.id, updates);
 
           if (previousActive && previousActive !== thread.id) {
@@ -131,9 +141,25 @@ export function createManagerHandlers(deps: ManagerDeps): HandlerDef[] {
           if (folderAdded) broadcast(window, IPC_CHANNELS.FOLDERS_CHANGED);
           broadcast(window, IPC_CHANNELS.THREADS_CHANGED);
 
+          // When this session was spawned for a scheduled task, append the
+          // [SCHEDULED TASK] postscript so the agent has the scheduleId it
+          // needs to call schedule_report. Single source of truth: the same
+          // helper used by SchedulerManager.executeDirect.
+          let promptToRun = args.prompt;
+          if (args.scheduledPromptId) {
+            const sched = getScheduledPrompt(args.scheduledPromptId);
+            if (sched) {
+              promptToRun = decoratePromptWithSchedule({
+                promptText: args.prompt,
+                prompt: sched,
+                workspace: args.workspace,
+              });
+            }
+          }
+
           const images = resolveImages(args.images);
           agentManager
-            .startStream(thread.id, args.prompt, images)
+            .startStream(thread.id, promptToRun, images)
             .catch((err) => {
               console.error(
                 `[mcp:manager] stream error for thread ${thread.id}:`,

--- a/packages/desktop/src/main/mcp/handlers/scheduler.ts
+++ b/packages/desktop/src/main/mcp/handlers/scheduler.ts
@@ -7,10 +7,12 @@ import {
   addScheduledPrompt,
   deleteScheduledPrompt,
   updateScheduledPrompt,
+  listScheduleRuns,
   FileStorageAdapter,
 } from "@stratosapp/core";
 import type { ScheduledPrompt } from "@stratosapp/core";
 import { type HandlerDef, defineHandler, textResult } from "./types";
+import { depositReport } from "../../scheduler/schedule-report-store";
 
 function buildSchedule(args: {
   once?: string;
@@ -47,7 +49,7 @@ export function createSchedulerHandlers(deps: SchedulerDeps): HandlerDef[] {
     defineHandler({
       name: "schedule_create",
       description:
-        "Create a new scheduled prompt that runs automatically in Stratos. Call schedule_folders first to get a valid folder name or path.",
+        "Create a new scheduled prompt that runs automatically in Stratos. Call schedule_folders first to get a valid folder name or path. To have the Manager dispatch the run instead of executing it directly, set routeToManager=true — but only if the work genuinely benefits from Manager orchestration (conflict checks, batching). When routeToManager is true, the prompt MUST be fully self-describing — include all relevant context, goals, and constraints inline. Do not reference 'earlier discussion', 'the analysis above', or any prior session state, since the Manager's history at fire time will not contain it.",
       inputSchema: {
         name: z.string().describe("Human-readable schedule name"),
         prompt: z.string().describe("Prompt text to run on each execution"),
@@ -104,6 +106,12 @@ export function createSchedulerHandlers(deps: SchedulerDeps): HandlerDef[] {
           .describe(
             "Day of week for weekly schedules (0=Sun … 6=Sat, default: 1=Mon)",
           ),
+        routeToManager: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, the schedule fires by posting to the Manager (which then dispatches a session) instead of running the prompt directly. Use only when Manager intelligence is needed (conflict checks, batching, contextual rewriting). Default: false. When true, the prompt must be fully self-describing.",
+          ),
       },
       handler: async (args) => {
         const folders = storage.listFolders();
@@ -135,6 +143,7 @@ export function createSchedulerHandlers(deps: SchedulerDeps): HandlerDef[] {
           schedule,
           enabled: true,
           ...(args.model ? { model: args.model } : {}),
+          ...(args.routeToManager ? { routeToManager: true } : {}),
         } as Omit<ScheduledPrompt, "id" | "createdAt">);
         return textResult(JSON.stringify(entry, null, 2));
       },
@@ -162,12 +171,40 @@ export function createSchedulerHandlers(deps: SchedulerDeps): HandlerDef[] {
             schedule: sched,
             folder: folder?.name ?? "?",
             provider: p.provider,
+            routeToManager: p.routeToManager ?? false,
             lastRunAt: p.lastRunAt ?? null,
             lastRunStatus: p.lastRunStatus ?? null,
           };
         });
         return textResult(
           list.length ? JSON.stringify(list, null, 2) : "No scheduled prompts.",
+        );
+      },
+    }),
+    defineHandler({
+      name: "schedule_runs",
+      description:
+        "Query the log of past scheduled-prompt run completions (newest first). Includes status, agent-authored summary (if filed), duration, and error message. Use this to check what scheduled tasks have completed recently and what they reported.",
+      inputSchema: {
+        scheduleId: z
+          .string()
+          .optional()
+          .describe("Filter to runs of a specific schedule"),
+        limit: z
+          .number()
+          .optional()
+          .describe("Max records to return (default: 20, max: 100)"),
+      },
+      handler: async (args) => {
+        const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+        const runs = listScheduleRuns({
+          ...(args.scheduleId ? { scheduleId: args.scheduleId } : {}),
+          limit,
+        });
+        return textResult(
+          runs.length
+            ? JSON.stringify(runs, null, 2)
+            : "No scheduled-prompt runs recorded yet.",
         );
       },
     }),
@@ -209,6 +246,27 @@ export function createSchedulerHandlers(deps: SchedulerDeps): HandlerDef[] {
         return updated
           ? textResult(`Disabled schedule: ${args.id}`)
           : textResult(`Not found: ${args.id}`, true);
+      },
+    }),
+    defineHandler({
+      name: "schedule_report",
+      description:
+        "Deposit a concise summary of a scheduled task run. Call this at the end of a scheduled run with the scheduleId from the [SCHEDULED TASK] context block. The summary is forwarded to the Manager when the run completes. This tool only stores data — it has no other side effects.",
+      inputSchema: {
+        scheduleId: z
+          .string()
+          .describe(
+            "The scheduleId from the [SCHEDULED TASK] context block in your prompt.",
+          ),
+        summary: z
+          .string()
+          .describe(
+            "1-3 sentence summary of what you accomplished, found, or changed.",
+          ),
+      },
+      handler: async (args) => {
+        depositReport(args.scheduleId, args.summary);
+        return textResult(JSON.stringify({ status: "recorded" }, null, 2));
       },
     }),
     defineHandler({

--- a/packages/desktop/src/main/scheduler/decorate-prompt.ts
+++ b/packages/desktop/src/main/scheduler/decorate-prompt.ts
@@ -1,0 +1,33 @@
+/**
+ * Builds the [SCHEDULED TASK] context postscript appended to a scheduled
+ * prompt's text before execution. Single source of truth for both:
+ *   - executeDirect (scheduler builds the thread itself)
+ *   - create_session (Manager builds the thread when routeToManager: true)
+ *
+ * The postscript gives the agent the scheduleId it needs for schedule_report.
+ */
+import type { ScheduledPrompt } from "@stratosapp/core";
+
+export function buildSchedulePostscript(args: {
+  prompt: ScheduledPrompt;
+  workspace: string;
+}): string {
+  return [
+    "",
+    "---",
+    `[SCHEDULED TASK — ${args.prompt.name}]`,
+    `Schedule ID: ${args.prompt.id}`,
+    `Workspace: ${args.workspace}`,
+    `Provider: ${args.prompt.provider}`,
+    "",
+    `When you finish, call mcp__stratos__schedule_report with scheduleId="${args.prompt.id}" and a concise 1-3 sentence summary of what you accomplished, found, or changed. The Manager will receive this summary as a status update.`,
+  ].join("\n");
+}
+
+export function decoratePromptWithSchedule(args: {
+  promptText: string;
+  prompt: ScheduledPrompt;
+  workspace: string;
+}): string {
+  return args.promptText + "\n" + buildSchedulePostscript(args);
+}

--- a/packages/desktop/src/main/scheduler/schedule-report-store.ts
+++ b/packages/desktop/src/main/scheduler/schedule-report-store.ts
@@ -1,0 +1,32 @@
+/**
+ * Transient in-memory store for agent-authored summaries deposited via the
+ * `schedule_report` MCP tool. The scheduler reads from this when a run
+ * completes and includes the summary in the Manager notification.
+ *
+ * Entries are keyed by scheduleId. The scheduler clears the entry after
+ * consuming it, so a stale summary from a prior run cannot leak into a
+ * later run of the same schedule.
+ */
+
+interface PendingReport {
+  summary: string;
+  depositedAt: number;
+}
+
+const pending = new Map<string, PendingReport>();
+
+export function depositReport(scheduleId: string, summary: string): void {
+  pending.set(scheduleId, { summary, depositedAt: Date.now() });
+}
+
+/** Read and remove the pending summary for a schedule. */
+export function consumeReport(scheduleId: string): PendingReport | undefined {
+  const entry = pending.get(scheduleId);
+  if (entry) pending.delete(scheduleId);
+  return entry;
+}
+
+/** Discard any pending summary without consuming. Used when a run is cancelled. */
+export function clearReport(scheduleId: string): void {
+  pending.delete(scheduleId);
+}

--- a/packages/desktop/src/main/scheduler/scheduler.ts
+++ b/packages/desktop/src/main/scheduler/scheduler.ts
@@ -6,13 +6,20 @@ import { join } from "path";
 import { homedir } from "os";
 import { IPC_CHANNELS } from "../../common/ipc-channels";
 import type { AgentManager } from "../agent-manager";
-import type { ScheduledPrompt } from "@stratosapp/core";
+import type {
+  ScheduledPrompt,
+  ScheduleRunRecord,
+  Folder,
+} from "@stratosapp/core";
 import {
   loadScheduledPrompts,
   updateScheduledPrompt,
   FileStorageAdapter,
   scheduleToCron,
 } from "@stratosapp/core";
+import type { ManagerSession } from "../manager/manager-session";
+import { consumeReport, clearReport } from "./schedule-report-store";
+import { decoratePromptWithSchedule } from "./decorate-prompt";
 
 export class SchedulerManager {
   private tasks = new Map<string, ScheduledTask>();
@@ -21,6 +28,7 @@ export class SchedulerManager {
   private storage: FileStorageAdapter;
   private window: BrowserWindow;
   private fileWatcher: FSWatcher | null = null;
+  private managerSession: ManagerSession | null = null;
 
   constructor(
     agentManager: AgentManager,
@@ -30,6 +38,15 @@ export class SchedulerManager {
     this.agentManager = agentManager;
     this.storage = storage;
     this.window = window;
+  }
+
+  /**
+   * Wire the ManagerSession reference. Done after both have been constructed
+   * since ManagerSession is initialized after SchedulerManager in main/index.ts.
+   * Required for routeToManager schedules and for completion notifications.
+   */
+  setManagerSession(managerSession: ManagerSession): void {
+    this.managerSession = managerSession;
   }
 
   /** Load all enabled schedules from disk and start the file watcher. */
@@ -99,7 +116,23 @@ export class SchedulerManager {
       return null;
     }
 
-    // Create thread
+    if (prompt.routeToManager) {
+      return this.executeViaManager(prompt, folder);
+    }
+    return this.executeDirect(prompt, folder);
+  }
+
+  /**
+   * Default execution path: scheduler creates the thread itself and runs the
+   * prompt directly via AgentManager. Manager is notified on completion via
+   * a lightweight record (success) or a real LLM turn (failure).
+   */
+  private async executeDirect(
+    prompt: ScheduledPrompt,
+    folder: Folder,
+  ): Promise<string | null> {
+    const startedAt = Date.now();
+
     const now = new Date();
     const dateStr = now.toLocaleString(undefined, {
       month: "short",
@@ -115,46 +148,47 @@ export class SchedulerManager {
       prompt.provider,
     );
 
-    // Set scheduledPromptId and mode on the thread
     this.storage.updateThread(thread.id, {
       scheduledPromptId: prompt.id,
       mode: "bypassPermissions",
     });
 
-    // Update run status
     updateScheduledPrompt(prompt.id, {
-      lastRunAt: Date.now(),
+      lastRunAt: startedAt,
       lastRunThreadId: thread.id,
       lastRunStatus: "running",
     });
     this.notifyChanged();
 
-    // Execute in background
+    // Make sure no stale summary from a prior run is consumed by this one.
+    clearReport(prompt.id);
+
+    const decoratedPrompt = this.decoratePromptWithContext(prompt, folder);
+
     this.agentManager
-      .runScheduledPrompt(thread.id, prompt.prompt)
+      .runScheduledPrompt(thread.id, decoratedPrompt)
       .then(() => {
         updateScheduledPrompt(prompt.id, { lastRunStatus: "completed" });
         this.notifyChanged();
-        this.notifyRunFinished(prompt, thread.id, "completed");
+        this.finalizeRun(prompt, folder, thread.id, startedAt, "completed");
       })
       .catch((err) => {
-        updateScheduledPrompt(prompt.id, {
-          lastRunStatus: "error",
-        });
+        updateScheduledPrompt(prompt.id, { lastRunStatus: "error" });
         this.notifyChanged();
         console.error(
           `[scheduler] Error executing scheduled prompt ${prompt.id}:`,
           err,
         );
-        this.notifyRunFinished(
+        this.finalizeRun(
           prompt,
+          folder,
           thread.id,
+          startedAt,
           "error",
           err instanceof Error ? err.message : String(err),
         );
       });
 
-    // For one-time schedules, auto-disable after execution
     if (prompt.schedule.type === "once") {
       updateScheduledPrompt(prompt.id, { enabled: false });
       this.unschedulePrompt(prompt.id);
@@ -162,6 +196,131 @@ export class SchedulerManager {
     }
 
     return thread.id;
+  }
+
+  /**
+   * routeToManager execution path: scheduler hands the prompt off to the
+   * Manager, which decides how to dispatch (typically by calling create_session
+   * with the schedule context). When the Manager-spawned child completes,
+   * ManagerSession invokes the callback registered here so we can update
+   * bookkeeping. We do NOT create the thread ourselves — Manager owns that.
+   */
+  private async executeViaManager(
+    prompt: ScheduledPrompt,
+    folder: Folder,
+  ): Promise<string | null> {
+    if (!this.managerSession) {
+      console.error(
+        `[scheduler] routeToManager schedule ${prompt.id} fired before ManagerSession was wired; falling back to direct execution`,
+      );
+      return this.executeDirect(prompt, folder);
+    }
+
+    const startedAt = Date.now();
+
+    updateScheduledPrompt(prompt.id, {
+      lastRunAt: startedAt,
+      lastRunStatus: "running",
+    });
+    this.notifyChanged();
+
+    clearReport(prompt.id);
+
+    this.managerSession.sendFromScheduler(
+      prompt,
+      folder.path,
+      (status, errorMessage) => {
+        updateScheduledPrompt(prompt.id, { lastRunStatus: status });
+        this.notifyChanged();
+        // We don't know the threadId — Manager spawned it. Look it up from
+        // storage by scheduledPromptId. Best-effort; fall back to "" if not
+        // found (record still useful with workspace + summary).
+        const threads = this.storage.listThreads();
+        const childThread = [...threads]
+          .reverse()
+          .find(
+            (t) =>
+              t.scheduledPromptId === prompt.id && t.spawnedBy === "manager",
+          );
+        const threadId = childThread?.id ?? "";
+        if (threadId) {
+          updateScheduledPrompt(prompt.id, { lastRunThreadId: threadId });
+        }
+        this.finalizeRun(
+          prompt,
+          folder,
+          threadId,
+          startedAt,
+          status,
+          errorMessage,
+        );
+      },
+    );
+
+    if (prompt.schedule.type === "once") {
+      updateScheduledPrompt(prompt.id, { enabled: false });
+      this.unschedulePrompt(prompt.id);
+      this.notifyChanged();
+    }
+
+    // No threadId yet — Manager hasn't spawned it.
+    return null;
+  }
+
+  /**
+   * Append the [SCHEDULED TASK] context block to the prompt so the agent has
+   * the scheduleId it needs for schedule_report and knows it's running in
+   * scheduled mode. Delegates to the shared builder so the routed path
+   * (create_session MCP tool) can produce the same postscript.
+   */
+  private decoratePromptWithContext(
+    prompt: ScheduledPrompt,
+    folder: Folder,
+  ): string {
+    return decoratePromptWithSchedule({
+      promptText: prompt.prompt,
+      prompt,
+      workspace: folder.path,
+    });
+  }
+
+  /**
+   * Always called when a scheduled run finishes (either path). Builds a
+   * ScheduleRunRecord with any agent-deposited summary and routes it to the
+   * Manager — lightweight record for success, real LLM turn for failure.
+   */
+  private finalizeRun(
+    prompt: ScheduledPrompt,
+    folder: Folder,
+    threadId: string,
+    startedAt: number,
+    status: "completed" | "error",
+    errorMessage?: string,
+  ): void {
+    const completedAt = Date.now();
+    const pending = consumeReport(prompt.id);
+    const record: ScheduleRunRecord = {
+      scheduleId: prompt.id,
+      scheduleName: prompt.name,
+      threadId,
+      workspace: folder.path,
+      provider: prompt.provider,
+      status,
+      ...(pending?.summary ? { summary: pending.summary } : {}),
+      durationMs: completedAt - startedAt,
+      ...(errorMessage ? { errorMessage } : {}),
+      startedAt,
+      completedAt,
+    };
+
+    if (this.managerSession) {
+      this.managerSession.recordScheduleRun(record);
+      if (status === "error") {
+        this.managerSession.reportScheduleFailure(record);
+      }
+    }
+
+    this.notifyRunFinished(prompt, threadId, status, errorMessage);
   }
 
   /** Reschedule all prompts (call after CRUD changes). */


### PR DESCRIPTION
## Summary

- Scheduler always notifies the Manager when a scheduled prompt finishes — lightweight `ScheduleRunRecord` for success, real Manager LLM turn for failure.
- New `schedule_report` MCP tool lets the running agent deposit a 1-3 sentence summary that's included in the run record. Run records persist at `~/.stratos/manager/schedule-runs.json` and are queryable via the new `schedule_runs` MCP tool.
- New opt-in `routeToManager` flag on `ScheduledPrompt`: when true, the schedule fires by posting to the Manager (which dispatches via `create_session`) instead of running directly. Intended for agent-authored schedules that benefit from Manager intelligence (conflict checks, batching). The UI form does not expose it — only the `schedule_create` MCP tool does.

## Design

See `docs/schedules-through-manager.md` for the full design rationale, alternatives considered, and implementation plan.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm --filter @stratosapp/core test` — 157 passing
- [x] `pnpm --filter @stratosapp/desktop test` — 133 passing (tool counts updated for new `schedule_report` + `schedule_runs` tools)
- [x] `pnpm lint` — no new errors
- [x] **End-to-end CDP verification on a live app instance:**
  - Direct path (~9s): schedule fires → postscript injected → agent calls `schedule_report` → record persisted with agent-authored summary
  - Routed path (~20s): schedule fires → Manager dispatches via `create_session(scheduledPromptId)` → child agent runs → callback fires → record persisted with summary, `threadId` correctly tracked back through the Manager hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)