### PR TITLE
fix(manager): suppress notification on user-direct followup to spawned agent

### DIFF
--- a/packages/core/src/types/thread.ts
+++ b/packages/core/src/types/thread.ts
@@ -96,6 +96,12 @@ export interface Thread {
   /** The lastRunId whose completion notification was successfully enqueued.
    * When lastRunId === lastReportedRunId the notification was already sent. */
   lastReportedRunId?: string;
+  /** Origin of the most recent stream run, persisted at run start so that
+   * reconcile-on-startup (after a crash) can reconstruct the right
+   * notification behavior. "user" runs are silent (no Manager turn);
+   * "manager" runs trigger the standard completion directive; "scheduler"
+   * runs invoke the scheduler callback. */
+  lastRunOrigin?: "user" | "manager" | "scheduler";
   /** Final status of the last completed stream — persisted so the UI can show
    * a completion indicator after reload without relying on transient state. */
   lastCompletionStatus?: "completed" | "error" | "interrupted";

--- a/packages/desktop/src/main/__tests__/agent-manager.integration.test.ts
+++ b/packages/desktop/src/main/__tests__/agent-manager.integration.test.ts
@@ -202,18 +202,24 @@ describe("AgentManager (integration)", () => {
 
       (manager as any).emitStreamCompleted({
         threadId: "t1",
+        runId: "t1-1",
         status: "completed",
+        origin: "manager",
       });
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenCalledWith({
         threadId: "t1",
+        runId: "t1-1",
         status: "completed",
+        origin: "manager",
       });
 
       unsub();
       (manager as any).emitStreamCompleted({
         threadId: "t2",
+        runId: "t2-1",
         status: "error",
+        origin: "manager",
       });
       // After unsubscribe no further calls
       expect(listener).toHaveBeenCalledTimes(1);
@@ -233,7 +239,9 @@ describe("AgentManager (integration)", () => {
       expect(() =>
         (manager as any).emitStreamCompleted({
           threadId: "t1",
+          runId: "t1-1",
           status: "completed",
+          origin: "manager",
         }),
       ).not.toThrow();
       expect(bad).toHaveBeenCalledTimes(1);

--- a/packages/desktop/src/main/__tests__/manager-session-completion.test.ts
+++ b/packages/desktop/src/main/__tests__/manager-session-completion.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Focused unit tests for ManagerSession.handleChildCompletion — specifically
+ * the run-origin branch added so that user-direct followups on a manager-
+ * spawned thread do NOT enqueue a Manager notification (which would otherwise
+ * cause the Manager to confusedly summarize and forward to WhatsApp).
+ *
+ * We construct ManagerSession via `new (ManagerSession as any)(...)` to bypass
+ * the private constructor and skip setup() — the test only exercises the
+ * private completion handler.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: vi.fn(),
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
+}));
+
+vi.mock("@stratosapp/core", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@stratosapp/core")>();
+  return {
+    ...original,
+    createProvider: vi.fn(),
+    FileStorageAdapter: vi.fn(),
+    appendTraceEntry: vi.fn(),
+    appendScheduleRun: vi.fn(),
+  };
+});
+
+vi.mock("../settings/settings.store", () => ({
+  loadSettings: vi.fn().mockReturnValue({}),
+  getOpencodeProviderKeys: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../mcp/handlers", () => ({
+  createStratosHandlers: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../mcp/sdk-adapter", () => ({
+  handlersToSdkMcp: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../mcp/stdio-proxy", () => ({
+  getStratosMcpPath: vi.fn().mockReturnValue("/tmp/stratos-mcp"),
+  getStratosMcpSocketPath: vi.fn().mockReturnValue("/tmp/stratos.sock"),
+}));
+
+vi.mock("../integrations/claude-path", () => ({
+  resolveClaudePathOrUndefined: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./manager-ref", () => ({
+  setManagerRef: vi.fn(),
+}));
+
+vi.mock("./turn-state", () => ({
+  clearManagerTurnImages: vi.fn(),
+  setManagerTurnImages: vi.fn(),
+}));
+
+interface FakeThread {
+  id: string;
+  spawnedBy?: string;
+  scheduledPromptId?: string;
+  lastReportedRunId?: string;
+  reportedToManager?: boolean;
+  title?: string;
+  provider?: string;
+}
+
+function makeStorage(threads: Record<string, FakeThread>) {
+  return {
+    getThread: vi.fn((id: string) => threads[id] ?? null),
+    updateThread: vi.fn((id: string, updates: Record<string, unknown>) => {
+      if (threads[id]) Object.assign(threads[id], updates);
+      return threads[id] ?? null;
+    }),
+    listThreads: vi.fn(() => Object.values(threads)),
+  };
+}
+
+async function makeSession(storage: ReturnType<typeof makeStorage>) {
+  const mod = await import("../manager/manager-session");
+  const ManagerSession = (mod as unknown as { ManagerSession: unknown })
+    .ManagerSession;
+  // Bypass the private constructor; we only test handleChildCompletion which
+  // touches storage + private queue state.
+  const session = new (ManagerSession as unknown as new (
+    ...args: unknown[]
+  ) => unknown)(
+    /* agentManager */ {},
+    storage,
+    /* window */ {},
+  ) as unknown as Record<string, unknown>;
+
+  // Ensure the private state used by handleChildCompletion exists.
+  session.notificationQueue = [];
+  session.schedulerCallbacks = new Map();
+  session.activeStream = false;
+  session.isNotificationInFlight = false;
+  session.notificationBackoffUntil = 0;
+  return session;
+}
+
+describe("ManagerSession.handleChildCompletion — run origin behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("user-direct origin: persists ack but does NOT enqueue a notification", async () => {
+    const threads: Record<string, FakeThread> = {
+      t1: { id: "t1", spawnedBy: "manager", title: "child" },
+    };
+    const storage = makeStorage(threads);
+    const session = await makeSession(storage);
+
+    (
+      session as { handleChildCompletion: (e: unknown) => void }
+    ).handleChildCompletion({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "user",
+    });
+
+    // Ack persisted so we don't reprocess on reconcile.
+    expect(storage.updateThread).toHaveBeenCalledWith("t1", {
+      lastReportedRunId: "r1",
+      reportedToManager: true,
+    });
+    // No notification enqueued — Manager stays silent.
+    expect((session.notificationQueue as unknown[]).length).toBe(0);
+  });
+
+  it("manager origin: enqueues the standard completion directive", async () => {
+    const threads: Record<string, FakeThread> = {
+      t1: {
+        id: "t1",
+        spawnedBy: "manager",
+        title: "child",
+        provider: "claude-code",
+      },
+    };
+    const storage = makeStorage(threads);
+    const session = await makeSession(storage);
+    // Stub drainNotificationQueue so we don't try to actually start an LLM turn.
+    (session as Record<string, unknown>).drainNotificationQueue = vi.fn();
+
+    (
+      session as { handleChildCompletion: (e: unknown) => void }
+    ).handleChildCompletion({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "manager",
+    });
+
+    const queue = session.notificationQueue as Array<{
+      prompt: string;
+      threadId?: string;
+    }>;
+    expect(queue.length).toBe(1);
+    expect(queue[0].threadId).toBe("t1");
+    expect(queue[0].prompt).toContain("[stratos-notification]");
+    expect(queue[0].prompt).toContain('session="t1"');
+    // Drain attempted.
+    expect(
+      (session as { drainNotificationQueue: { mock: { calls: unknown[] } } })
+        .drainNotificationQueue.mock.calls.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("user-direct origin is dedup-checked: same runId twice → only first ack", async () => {
+    const threads: Record<string, FakeThread> = {
+      t1: { id: "t1", spawnedBy: "manager" },
+    };
+    const storage = makeStorage(threads);
+    const session = await makeSession(storage);
+
+    const handle = (
+      session as { handleChildCompletion: (e: unknown) => void }
+    ).handleChildCompletion.bind(session);
+    handle({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "user",
+    });
+    handle({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "user",
+    });
+
+    // First call writes the ack; second call is deduped before reaching the
+    // user-origin branch (lastReportedRunId === runId).
+    expect(storage.updateThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores completions for non-manager threads regardless of origin", async () => {
+    const threads: Record<string, FakeThread> = {
+      t1: { id: "t1" /* no spawnedBy */ },
+    };
+    const storage = makeStorage(threads);
+    const session = await makeSession(storage);
+
+    (
+      session as { handleChildCompletion: (e: unknown) => void }
+    ).handleChildCompletion({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "manager",
+    });
+
+    expect(storage.updateThread).not.toHaveBeenCalled();
+    expect((session.notificationQueue as unknown[]).length).toBe(0);
+  });
+
+  it("scheduler-routed thread (scheduledPromptId set) prefers scheduler callback over standard directive", async () => {
+    const threads: Record<string, FakeThread> = {
+      t1: {
+        id: "t1",
+        spawnedBy: "manager",
+        scheduledPromptId: "sched-1",
+      },
+    };
+    const storage = makeStorage(threads);
+    const session = await makeSession(storage);
+    const cb = vi.fn();
+    (session.schedulerCallbacks as Map<string, unknown>).set("sched-1", cb);
+
+    (
+      session as { handleChildCompletion: (e: unknown) => void }
+    ).handleChildCompletion({
+      threadId: "t1",
+      runId: "r1",
+      status: "completed",
+      origin: "manager",
+    });
+
+    expect(cb).toHaveBeenCalledWith("completed", undefined);
+    // No standard directive enqueued.
+    expect((session.notificationQueue as unknown[]).length).toBe(0);
+  });
+});

--- a/packages/desktop/src/main/agent-manager.ts
+++ b/packages/desktop/src/main/agent-manager.ts
@@ -262,11 +262,18 @@ function buildOllamaCustomProvider(): Record<
   };
 }
 
+export type RunOrigin = "user" | "manager" | "scheduler";
+
 export interface StreamCompletedEvent {
   threadId: string;
   runId: string;
   status: "completed" | "error" | "interrupted";
   errorMessage?: string;
+  /** Who initiated this stream run. Used by the Manager to decide whether to
+   * surface a completion directive — "user" runs are silent so the Manager
+   * doesn't auto-respond (or forward to WhatsApp) when the user talks to a
+   * manager-spawned agent directly. */
+  origin: RunOrigin;
 }
 
 interface ThreadSession {
@@ -881,6 +888,7 @@ export class AgentManager {
     threadId: string,
     prompt: string,
     images?: { dataUrl: string; mimeType: string }[],
+    origin: RunOrigin = "user",
   ): Promise<void> {
     // Each new stream attempt clears any prior interrupt intent so that a
     // user-triggered stop followed by a fresh send works correctly.
@@ -929,7 +937,10 @@ export class AgentManager {
     // enabling reconcile-on-startup to re-queue the missed notification.
     const runId = streamId;
     if (thread.spawnedBy === "manager") {
-      this.storage.updateThread(threadId, { lastRunId: runId });
+      this.storage.updateThread(threadId, {
+        lastRunId: runId,
+        lastRunOrigin: origin,
+      });
     }
 
     // Lazy worktree creation: if user selected worktree mode but no worktree exists yet
@@ -1326,7 +1337,7 @@ export class AgentManager {
         isRetrying = true;
         this.activeStreams.delete(threadId);
         this.threadEffectiveModes.delete(threadId);
-        return this.runStream(threadId, prompt, images);
+        return this.runStream(threadId, prompt, images, origin);
       }
 
       if (!specificErrorSent) {
@@ -1381,6 +1392,7 @@ export class AgentManager {
           threadId,
           runId,
           status,
+          origin,
           ...(caughtError && typeof (caughtError as any)?.message === "string"
             ? { errorMessage: (caughtError as any).message }
             : {}),
@@ -1910,13 +1922,17 @@ export class AgentManager {
     return this.activeStreams.has(threadId);
   }
 
-  /** Start a stream for a thread (used by ManagerSession bridge). */
+  /** Start a stream for a thread (used by ManagerSession bridge and MCP
+   * handlers). `origin` defaults to "manager" because all current callers of
+   * this public method are manager-driven; user-initiated runs go through
+   * the IPC SEND_MESSAGE handler which calls runStream directly. */
   async startStream(
     threadId: string,
     prompt: string,
     images?: { dataUrl: string; mimeType: string }[],
+    origin: RunOrigin = "manager",
   ): Promise<void> {
-    return this.runStream(threadId, prompt, images);
+    return this.runStream(threadId, prompt, images, origin);
   }
 
   /** Interrupt a running session (used by ManagerSession bridge). */

--- a/packages/desktop/src/main/manager/manager-session.ts
+++ b/packages/desktop/src/main/manager/manager-session.ts
@@ -655,6 +655,18 @@ export class ManagerSession {
       if (thread.reportedToManager) return;
     }
 
+    // User-direct followup: the user typed in the spawned agent's chat (not
+    // through the Manager). Persist the ack so we don't re-process this run,
+    // but do NOT enqueue any notification — the Manager wasn't involved and
+    // shouldn't react (must not auto-forward to WhatsApp either).
+    if (event.origin === "user") {
+      this.storage.updateThread(event.threadId, {
+        lastReportedRunId: event.runId,
+        reportedToManager: true,
+      });
+      return;
+    }
+
     // If this thread was spawned by Manager in response to a routeToManager
     // schedule (carries a scheduledPromptId), invoke the registered scheduler
     // callback so SchedulerManager can update bookkeeping. Skip the standard
@@ -702,7 +714,10 @@ export class ManagerSession {
         threadId: event.threadId,
       };
     } else {
-      this.notificationQueue.push({ prompt: directive, threadId: event.threadId });
+      this.notificationQueue.push({
+        prompt: directive,
+        threadId: event.threadId,
+      });
     }
 
     // Acknowledge AFTER enqueuing. If the process crashes between the push
@@ -733,6 +748,10 @@ export class ManagerSession {
         threadId: thread.id,
         runId: thread.lastRunId,
         status: thread.lastCompletionStatus,
+        // Pre-existing threads from before lastRunOrigin was tracked default
+        // to "manager" — that matches the historical behavior of always
+        // notifying the Manager on reconcile.
+        origin: thread.lastRunOrigin ?? "manager",
         ...(thread.lastCompletionError
           ? { errorMessage: thread.lastCompletionError }
           : {}),


### PR DESCRIPTION
## Summary

- When the user typed directly into a manager-spawned agent's chat, the completion event fired the same notification path as a manager-dispatched task. The Manager LLM ran with no context and forwarded the reply to WhatsApp.
- Tag each `runStream` with `origin` (`user` / `manager` / `scheduler`), persist `lastRunOrigin` on the thread at run start, and early-return in `handleChildCompletion` for `origin === "user"` — ack the run but do not enqueue a notification.
- `reconcileOnStartup` reads the persisted origin so crash-recovery routes correctly too (defaults to `manager` for pre-fix threads — preserves historical behavior).

## Test plan

- [x] New unit tests in `manager-session-completion.test.ts` cover user, manager, dedup, non-manager, and scheduler-routed paths (5/5 pass)
- [x] Existing `agent-manager.integration.test.ts` updated for new `StreamCompletedEvent` shape
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @stratosapp/desktop test` — 138 pass / 1 pre-existing skip
- [x] CDP end-to-end (raw WebSocket → `window.api.sendMessage` → observe `threads.json`):
  - User-direct followup: `lastRunOrigin: "user"`, ack persisted, Manager `lastRunId` and `updatedAt` unchanged → Manager LLM did NOT run
  - Verified on two different manager-spawned threads in a clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)