### PR TITLE
fix(turbo): build workspace deps before starting dev

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "outputs": ["dist/**", "out/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "persistent": true,
       "cache": false
     },


### PR DESCRIPTION
## Summary

- Adds `dependsOn: ["^build"]` to the `dev` task in `turbo.json`
- Ensures compiled workspace packages (e.g. `@stratosapp/gateway`) are built automatically before persistent dev processes start
- Fixes crash on `pnpm dev` after a fresh clone + `pnpm install` when `gateway/dist/` doesn't exist yet

## Test plan

- [ ] Fresh clone → `pnpm install` → `pnpm dev` should start without the `Cannot find module @stratosapp/gateway/dist/index.js` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)