### PR TITLE
feat(telegram): add Telegram gateway alongside WhatsApp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # CLAUDE.md — Stratos
 
-## WhatsApp Gateway Log
+## Messaging Gateway Log
 
-Gateway activity (connections, messages, errors) is written to a rotating log file — **not** shown in the UI.
+Gateway activity for both WhatsApp and Telegram (connections, messages, errors) is written to a single rotating log file — **not** shown in the UI.
 
 | Environment     | Path                                                     |
 | --------------- | -------------------------------------------------------- |

--- a/docs/telegram-integration.md
+++ b/docs/telegram-integration.md
@@ -1,0 +1,173 @@
+# Telegram Integration
+
+Stratos can be reached over Telegram: messages you send to your bot are
+forwarded to the Manager Agent, and replies come back in the same chat (and
+forum topic) you sent from.
+
+This guide walks through enabling the feature, creating a bot, finding your
+chat ID, and (optionally) using forum topics.
+
+---
+
+## 1. Enable the feature
+
+The Telegram UI is gated behind a flag file so it stays hidden by default:
+
+```bash
+touch ~/.stratos/telegram.json
+```
+
+Restart Stratos. **Settings → Telegram** now appears.
+
+---
+
+## 2. Get a bot token from @BotFather
+
+1. Open Telegram and search for [`@BotFather`](https://t.me/BotFather).
+2. Send `/newbot`.
+3. Pick a display name (e.g. `Stratos`) and a username ending in `bot`
+   (e.g. `my_stratos_bot`). Usernames must be globally unique.
+4. BotFather replies with a token that looks like:
+   ```
+   123456789:ABCdef-Gh1jKlMnOpQrStUvWxYz0AbCdEfGh
+   ```
+5. **Don't reuse a token across machines.** Telegram only lets one process
+   long-poll a bot at a time — a second consumer silently steals updates from
+   the first.
+6. (Optional but recommended) Lock down the bot:
+   - `/setjoingroups` → **Disable** (so nobody can drag the bot into random
+     groups).
+   - `/setprivacy` → **Disable** if you plan to use it in a group with topics
+     and want it to read every message; **Enable** for DM-only use.
+   - `/setdescription`, `/setuserpic` → cosmetic.
+
+Paste the token into **Settings → Telegram → Bot Token** and save. The token
+is stored in `~/Library/Application Support/Stratos/telegram-settings.json`
+(or the per-worktree `userData` dir in dev mode).
+
+---
+
+## 3. Find your chat ID
+
+The bot only responds to one trusted chat ID — every other sender is dropped.
+Three ways to find yours, easiest first:
+
+### a) Via the gateway log (works for any chat)
+
+1. With the bot token saved, click **Connect** in Settings.
+2. From the chat you want to authorise (DM, group, or forum topic), send the
+   bot any message — e.g. `/start`.
+3. Tail the gateway log:
+
+   ```bash
+   # Dev (worktree)
+   tail -f ~/.stratos/instances/$(ls ~/.stratos/instances/)/logs/gateway.log
+
+   # Packaged
+   tail -f "~/Library/Application Support/Stratos/logs/gateway.log"
+   ```
+
+4. You'll see a line like:
+   ```
+   [telegram] blocked: chat 123456789
+   ```
+   That number is your chat ID. Paste it into **Trusted Chat ID** and save.
+
+### b) Via [`@userinfobot`](https://t.me/userinfobot) (DMs only)
+
+DM that bot anything; it replies with your numeric user ID, which doubles as
+your DM chat ID.
+
+### c) Via the Bot API directly
+
+```bash
+curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq
+```
+
+After sending your bot a message, look for `message.chat.id`.
+
+### Chat ID shapes
+
+| Chat type          | Shape          | Example          |
+| ------------------ | -------------- | ---------------- |
+| Private (DM)       | positive int   | `123456789`      |
+| Group              | negative int   | `-100123456`     |
+| Supergroup / forum | `-100<digits>` | `-1001234567890` |
+
+Stratos accepts all three — use the value the log/API returns verbatim.
+
+---
+
+## 4. (Optional) Use forum topics
+
+If you want one Telegram chat that has multiple separate threads (e.g. one
+topic per project), use a Telegram **forum supergroup**:
+
+1. Create a new group (Telegram app → New Group).
+2. Add the bot as a member.
+3. Promote the group to a supergroup if it isn't already (sending the first
+   message usually triggers this automatically).
+4. Group settings → **Topics** → enable.
+5. Create the topics you want (one per project, conversation, etc.).
+6. The chat ID is the supergroup ID (`-100…`); you only need to paste it
+   once, even though the group has many topics.
+
+When you message the bot inside a topic, replies (including async Manager
+notifications about session completion) automatically land back in the same
+topic. There's nothing extra to configure — `message_thread_id` is preserved
+through the gateway.
+
+> ⚠️ **Manager state is shared across topics.** Stratos has a single Manager
+> Agent session for the whole app, so context flows between every topic you
+> use. The topic only controls **where the reply lands**, not which Manager
+> conversation it joins. If you want hard isolation per topic, dispatch
+> agent sessions explicitly via the Manager — those are per-thread.
+
+---
+
+## 5. Connect
+
+1. Settings → Telegram → **Connect**.
+2. Status pill flips through `connecting…` → `connected`. The tray menu
+   shows the same status.
+3. Send a message to your bot. The `typing…` indicator appears, the Manager
+   replies, the reply lands in the same chat (and topic).
+
+If `connecting…` flips to `error`, check the gateway log — most failures are
+either an invalid token (`auth failed`) or another process already polling
+the same bot (`409 Conflict`). The latter resolves itself when the other
+consumer disconnects.
+
+---
+
+## 6. Updating settings live
+
+- **Trusted Chat ID** — saving updates the running gateway immediately, no
+  reconnect required.
+- **Bot Token** — saving writes the new value to disk, but the running
+  client keeps the old token. Click **Disconnect** then **Connect** to swap.
+
+---
+
+## 7. Disabling
+
+Either:
+
+```bash
+rm ~/.stratos/telegram.json
+```
+
+(removes the UI section entirely on next restart) or just click
+**Disconnect** in Settings (gateway stops, settings are kept).
+
+---
+
+## Troubleshooting
+
+| Symptom                                           | Likely cause                                                                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Bot ignores you, log says `blocked: chat <id>`    | Trusted Chat ID doesn't match — copy the ID from the log.                                                     |
+| Status stuck on `connecting…`                     | Another process is long-polling the same token (cfo, another Stratos worktree). Kill it or use a fresh token. |
+| `409 Conflict` in log                             | Same as above — Telegram only allows one polling consumer per bot.                                            |
+| Replies land in **General** instead of your topic | You're on an old Stratos build that pre-dates the topic fix; rebuild and restart.                             |
+| Manager replies are slow / never come             | The Manager is busy with a previous turn; check the main UI for an active stream.                             |

--- a/packages/desktop/src/common/ipc-channels.ts
+++ b/packages/desktop/src/common/ipc-channels.ts
@@ -174,6 +174,15 @@ export const IPC_CHANNELS = {
   WHATSAPP_LOG: "whatsapp:log", // event → log line string
   WHATSAPP_IS_ENABLED: "whatsapp:is-enabled",
 
+  // Telegram gateway
+  TELEGRAM_GET_STATE: "telegram:get-state",
+  TELEGRAM_CONNECT: "telegram:connect",
+  TELEGRAM_DISCONNECT: "telegram:disconnect",
+  TELEGRAM_SAVE_SETTINGS: "telegram:save-settings",
+  TELEGRAM_STATUS: "telegram:status", // event → "connected" | "disconnected" | "connecting" | "error"
+  TELEGRAM_LOG: "telegram:log", // event → log line string
+  TELEGRAM_IS_ENABLED: "telegram:is-enabled",
+
   // Terminal
   TERMINAL_CREATE: "terminal:create",
   TERMINAL_WRITE: "terminal:write",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -67,6 +67,14 @@ import {
 } from "./integrations/whatsapp.ipc";
 import { isWhatsAppEnabled } from "./integrations/whatsapp-flag";
 import {
+  registerTelegramIpc,
+  unregisterTelegramIpc,
+  getTelegramStatus,
+  onTelegramStatusChange,
+  connectTelegram,
+} from "./integrations/telegram.ipc";
+import { isTelegramEnabled } from "./integrations/telegram-flag";
+import {
   registerDirectoryIpc,
   unregisterDirectoryIpc,
 } from "./settings/directory.ipc";
@@ -298,6 +306,10 @@ if (!gotLock) {
     if (isWhatsAppEnabled()) {
       registerWhatsAppIpc(mainWindow);
     }
+    ipcMain.handle(IPC_CHANNELS.TELEGRAM_IS_ENABLED, () => isTelegramEnabled());
+    if (isTelegramEnabled()) {
+      registerTelegramIpc(mainWindow);
+    }
     registerDirectoryIpc(mainWindow);
     registerSettingsIpc(mainWindow);
     setSlashCommandsGetter(() => agentManager?.getSlashCommands() ?? []);
@@ -414,6 +426,28 @@ if (!gotLock) {
           items.push({ type: "separator" });
         }
 
+        if (isTelegramEnabled()) {
+          const tgStatus = getTelegramStatus();
+          const tgLabel =
+            tgStatus === "connected"
+              ? "● Telegram Connected"
+              : tgStatus === "connecting"
+                ? "◌ Telegram — connecting…"
+                : tgStatus === "error"
+                  ? "⚠ Telegram Error"
+                  : "○ Telegram Disconnected";
+          items.push({ label: tgLabel, enabled: false });
+          if (tgStatus === "disconnected" || tgStatus === "error") {
+            items.push({
+              label: "Connect Telegram",
+              click: () => {
+                connectTelegram().catch(console.error);
+              },
+            });
+          }
+          items.push({ type: "separator" });
+        }
+
         items.push({
           label: "Quit Stratos",
           click: () => {
@@ -423,6 +457,7 @@ if (!gotLock) {
             ipcMain.removeHandler(IPC_CHANNELS.APP_INFO);
             ipcMain.removeHandler(IPC_CHANNELS.SHELL_OPEN_EXTERNAL);
             ipcMain.removeHandler(IPC_CHANNELS.WHATSAPP_IS_ENABLED);
+            ipcMain.removeHandler(IPC_CHANNELS.TELEGRAM_IS_ENABLED);
             unregisterManagerIpc();
             unregisterSchedulerIpc();
             unregisterThreadIpc();
@@ -430,6 +465,7 @@ if (!gotLock) {
             unregisterClaudeIpc();
             unregisterCodexIpc();
             if (isWhatsAppEnabled()) unregisterWhatsAppIpc();
+            if (isTelegramEnabled()) unregisterTelegramIpc();
             unregisterDirectoryIpc();
             unregisterSettingsIpc();
             unregisterSkillsIpc();
@@ -447,6 +483,7 @@ if (!gotLock) {
 
       rebuildMenu();
       if (isWhatsAppEnabled()) onWhatsAppStatusChange(() => rebuildMenu());
+      if (isTelegramEnabled()) onTelegramStatusChange(() => rebuildMenu());
       // Double-click / left-click on macOS shows the window
       tray.on("double-click", () => {
         if (mainWindow) {

--- a/packages/desktop/src/main/integrations/telegram-flag.ts
+++ b/packages/desktop/src/main/integrations/telegram-flag.ts
@@ -1,0 +1,12 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+let _cached: boolean | null = null;
+
+export function isTelegramEnabled(): boolean {
+  if (_cached === null) {
+    _cached = existsSync(join(homedir(), ".stratos", "telegram.json"));
+  }
+  return _cached;
+}

--- a/packages/desktop/src/main/integrations/telegram.ipc.ts
+++ b/packages/desktop/src/main/integrations/telegram.ipc.ts
@@ -1,0 +1,248 @@
+import { BrowserWindow, ipcMain, app } from "electron";
+import { join } from "path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  statSync,
+  renameSync,
+  appendFileSync,
+} from "fs";
+import { IPC_CHANNELS } from "../../common/ipc-channels";
+import {
+  startTelegramGateway,
+  stopTelegramGateway,
+  updateGatewayTrustedChatId,
+  sendProactiveTelegram,
+} from "@stratosapp/gateway";
+import { getManagerRef } from "../manager/manager-ref";
+
+// ---------------------------------------------------------------------------
+// Settings persistence
+// ---------------------------------------------------------------------------
+
+interface TelegramSettings {
+  botToken: string;
+  trustedChatId: string;
+}
+
+function settingsPath(): string {
+  return join(app.getPath("userData"), "telegram-settings.json");
+}
+
+function loadSettings(): TelegramSettings {
+  try {
+    const raw = JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    return {
+      botToken: (raw.botToken as string) ?? "",
+      trustedChatId: (raw.trustedChatId as string) ?? "",
+    };
+  } catch {
+    return { botToken: "", trustedChatId: "" };
+  }
+}
+
+function saveSettings(s: TelegramSettings): void {
+  writeFileSync(settingsPath(), JSON.stringify(s, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Shared gateway log (same file as WhatsApp — both are messaging gateways)
+// ---------------------------------------------------------------------------
+
+const LOG_MAX_BYTES = 5 * 1024 * 1024;
+
+function gatewayLogPath(): string {
+  const dir = join(app.getPath("userData"), "logs");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return join(dir, "gateway.log");
+}
+
+function writeGatewayLog(line: string): void {
+  const filePath = gatewayLogPath();
+  try {
+    if (existsSync(filePath) && statSync(filePath).size > LOG_MAX_BYTES) {
+      renameSync(filePath, filePath + ".1");
+    }
+    appendFileSync(
+      filePath,
+      `[${new Date().toISOString()}] ${line}\n`,
+      "utf-8",
+    );
+  } catch {
+    // Non-fatal — never crash the gateway over logging
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime state
+// ---------------------------------------------------------------------------
+
+type TgStatus = "connected" | "disconnected" | "connecting" | "error";
+
+let status: TgStatus = "disconnected";
+let win: BrowserWindow | null = null;
+let lastChatId: string | null = null;
+let lastThreadId: number | undefined = undefined;
+const statusListeners: Array<(s: TgStatus) => void> = [];
+
+export function getTelegramStatus(): TgStatus {
+  return status;
+}
+
+export function onTelegramStatusChange(cb: (s: TgStatus) => void): () => void {
+  statusListeners.push(cb);
+  return () => {
+    const i = statusListeners.indexOf(cb);
+    if (i >= 0) statusListeners.splice(i, 1);
+  };
+}
+
+function emit(channel: string, payload?: unknown) {
+  win?.webContents.send(channel, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Core connect logic (shared by auto-connect and manual IPC)
+// ---------------------------------------------------------------------------
+
+export async function connectTelegram(): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  if (status === "connected" || status === "connecting") return { ok: true };
+  const settings = loadSettings();
+  if (!settings.botToken) {
+    return { ok: false, error: "Bot token not configured" };
+  }
+  status = "connecting";
+  emit(IPC_CHANNELS.TELEGRAM_STATUS, status);
+  try {
+    await startTelegramGateway(
+      {
+        botToken: settings.botToken,
+        trustedChatId: settings.trustedChatId,
+      },
+      {
+        onStatus(s) {
+          status = s;
+          emit(IPC_CHANNELS.TELEGRAM_STATUS, s);
+          statusListeners.forEach((cb) => cb(s));
+        },
+        onLog(line) {
+          writeGatewayLog(line);
+        },
+        async onMessage(from, text, threadId) {
+          const tag = threadId ? ` (topic ${threadId})` : "";
+          writeGatewayLog(
+            `[telegram-ipc] message from ${from}${tag}: ${text.slice(0, 60)}`,
+          );
+          const manager = getManagerRef();
+          if (!manager) {
+            writeGatewayLog("[telegram-ipc] manager ref not ready");
+            throw new Error("Manager not ready");
+          }
+          if (manager.isActive) {
+            writeGatewayLog("[telegram-ipc] manager is busy");
+            throw new Error("Manager is busy");
+          }
+          writeGatewayLog("[telegram-ipc] forwarding to manager");
+          lastChatId = from;
+          lastThreadId = threadId;
+          // Register a forward function so async child-completion
+          // notifications also land in the same chat (and topic) the user
+          // last sent from.
+          manager.setNotificationForward((replyText: string) =>
+            sendProactiveTelegram(from, replyText, threadId),
+          );
+          return new Promise<string>((resolve, reject) => {
+            manager
+              .sendFromGateway(text, (reply) => {
+                writeGatewayLog(
+                  `[telegram-ipc] manager replied: ${reply.slice(0, 60)}`,
+                );
+                resolve(reply);
+              })
+              .catch(reject);
+          });
+        },
+      },
+    );
+    return { ok: true };
+  } catch (err) {
+    status = "error";
+    emit(IPC_CHANNELS.TELEGRAM_STATUS, status);
+    statusListeners.forEach((cb) => cb(status));
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IPC Registration
+// ---------------------------------------------------------------------------
+
+export function registerTelegramIpc(window: BrowserWindow): void {
+  win = window;
+
+  ipcMain.handle(IPC_CHANNELS.TELEGRAM_GET_STATE, () => {
+    const settings = loadSettings();
+    return {
+      status,
+      botTokenSet: Boolean(settings.botToken),
+      trustedChatId: settings.trustedChatId,
+    };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.TELEGRAM_CONNECT, () => connectTelegram());
+
+  ipcMain.handle(IPC_CHANNELS.TELEGRAM_DISCONNECT, async () => {
+    await stopTelegramGateway();
+    status = "disconnected";
+    lastChatId = null;
+    lastThreadId = undefined;
+    getManagerRef()?.setNotificationForward(null);
+    emit(IPC_CHANNELS.TELEGRAM_STATUS, "disconnected");
+    statusListeners.forEach((cb) => cb("disconnected"));
+    return { ok: true };
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.TELEGRAM_SAVE_SETTINGS,
+    (_e, settings: Partial<TelegramSettings>) => {
+      const current = loadSettings();
+      const merged: TelegramSettings = {
+        botToken: settings.botToken ?? current.botToken,
+        trustedChatId: settings.trustedChatId ?? current.trustedChatId,
+      };
+      saveSettings(merged);
+      // The trusted chat id can be updated live; bot token requires reconnect.
+      updateGatewayTrustedChatId(merged.trustedChatId);
+      return { ok: true };
+    },
+  );
+
+  // Auto-connect if we have both a bot token and a trusted chat id.
+  if (loadSettings().botToken && loadSettings().trustedChatId) {
+    setTimeout(() => {
+      connectTelegram().catch((err) =>
+        console.error("[telegram] auto-connect failed:", err),
+      );
+    }, 3000);
+  }
+}
+
+export function unregisterTelegramIpc(): void {
+  ipcMain.removeHandler(IPC_CHANNELS.TELEGRAM_GET_STATE);
+  ipcMain.removeHandler(IPC_CHANNELS.TELEGRAM_CONNECT);
+  ipcMain.removeHandler(IPC_CHANNELS.TELEGRAM_DISCONNECT);
+  ipcMain.removeHandler(IPC_CHANNELS.TELEGRAM_SAVE_SETTINGS);
+  stopTelegramGateway().catch(() => {});
+  win = null;
+}

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -607,6 +607,36 @@ const api = {
     },
   },
 
+  // Telegram gateway
+  telegram: {
+    isEnabled: (): Promise<boolean> =>
+      ipcRenderer.invoke(IPC_CHANNELS.TELEGRAM_IS_ENABLED),
+    getState: () => ipcRenderer.invoke(IPC_CHANNELS.TELEGRAM_GET_STATE),
+    connect: () => ipcRenderer.invoke(IPC_CHANNELS.TELEGRAM_CONNECT),
+    disconnect: () => ipcRenderer.invoke(IPC_CHANNELS.TELEGRAM_DISCONNECT),
+    saveSettings: (s: { botToken?: string; trustedChatId?: string }) =>
+      ipcRenderer.invoke(IPC_CHANNELS.TELEGRAM_SAVE_SETTINGS, s),
+    onStatus: (
+      cb: (
+        status: "connected" | "disconnected" | "connecting" | "error",
+      ) => void,
+    ) => {
+      const handler = (
+        _: unknown,
+        status: "connected" | "disconnected" | "connecting" | "error",
+      ) => cb(status);
+      ipcRenderer.on(IPC_CHANNELS.TELEGRAM_STATUS, handler);
+      return () =>
+        ipcRenderer.removeListener(IPC_CHANNELS.TELEGRAM_STATUS, handler);
+    },
+    onLog: (cb: (line: string) => void) => {
+      const handler = (_: unknown, line: string) => cb(line);
+      ipcRenderer.on(IPC_CHANNELS.TELEGRAM_LOG, handler);
+      return () =>
+        ipcRenderer.removeListener(IPC_CHANNELS.TELEGRAM_LOG, handler);
+    },
+  },
+
   // Skills
   skills: {
     list: (): Promise<

--- a/packages/desktop/src/renderer/bridge.ts
+++ b/packages/desktop/src/renderer/bridge.ts
@@ -86,6 +86,15 @@ export function createDesktopBridge(): StratosContextValue {
       onLog: (cb) => window.api.whatsapp.onLog(cb),
     },
 
+    telegram: {
+      getState: () => window.api.telegram.getState(),
+      connect: () => window.api.telegram.connect(),
+      disconnect: () => window.api.telegram.disconnect(),
+      saveSettings: (s) => window.api.telegram.saveSettings(s),
+      onStatus: (cb) => window.api.telegram.onStatus(cb),
+      onLog: (cb) => window.api.telegram.onLog(cb),
+    },
+
     files: {
       listDirectory: (dirPath, rootPath) =>
         window.api.filesListDir(dirPath, rootPath),

--- a/packages/desktop/src/renderer/components/SettingsDialog.tsx
+++ b/packages/desktop/src/renderer/components/SettingsDialog.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from "react";
-import { Dialog, DialogBody, Button, WhatsAppSettings } from "@stratosapp/ui";
+import {
+  Dialog,
+  DialogBody,
+  Button,
+  WhatsAppSettings,
+  TelegramSettings,
+} from "@stratosapp/ui";
 import type { ElectronAPI } from "../../preload/index";
 
 declare const window: Window & typeof globalThis & { api: ElectronAPI };
@@ -49,8 +55,10 @@ export function SettingsDialog({
   onThemeChange,
 }: Props): React.ReactElement | null {
   const [whatsappEnabled, setWhatsappEnabled] = useState(false);
+  const [telegramEnabled, setTelegramEnabled] = useState(false);
   useEffect(() => {
     window.api.whatsapp.isEnabled().then(setWhatsappEnabled);
+    window.api.telegram.isEnabled().then(setTelegramEnabled);
   }, []);
 
   return (
@@ -178,6 +186,19 @@ export function SettingsDialog({
                 WhatsApp
               </h3>
               <WhatsAppSettings />
+            </section>
+          )}
+
+          {/* Telegram — only shown when ~/.stratos/telegram.json exists */}
+          {telegramEnabled && (
+            <section>
+              <h3
+                className="text-xs font-semibold uppercase tracking-wider mb-3"
+                style={{ color: "var(--text-muted)" }}
+              >
+                Telegram
+              </h3>
+              <TelegramSettings />
             </section>
           )}
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stratosapp/gateway",
   "version": "0.0.1",
-  "description": "Stratos WhatsApp gateway — in-process WhatsApp bridge for the Manager Agent",
+  "description": "Stratos messaging gateways — in-process WhatsApp + Telegram bridges for the Manager Agent",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -23,10 +23,12 @@
   "dependencies": {
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "node-telegram-bot-api": "^0.66.0",
     "pino": "^9.6.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",
+    "@types/node-telegram-bot-api": "^0.64.7",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -63,3 +63,13 @@ export function stopGateway(): void {
 }
 
 export { sendProactiveWhatsApp };
+
+// Telegram gateway
+export {
+  startTelegramGateway,
+  stopTelegramGateway,
+  updateGatewayTrustedChatId,
+  sendProactiveTelegram,
+  type TelegramGatewayConfig,
+  type TelegramGatewayCallbacks,
+} from "./telegram/index.js";

--- a/packages/gateway/src/telegram/client.ts
+++ b/packages/gateway/src/telegram/client.ts
@@ -1,0 +1,71 @@
+import TelegramBot from "node-telegram-bot-api";
+
+export interface TelegramCallbacks {
+  onStatus(status: "connected" | "disconnected" | "error"): void;
+  onLog(line: string): void;
+}
+
+export type OnReady = (bot: TelegramBot) => void;
+
+let currentBot: TelegramBot | null = null;
+
+export async function startTelegramBot(
+  token: string,
+  onReady: OnReady,
+  callbacks: TelegramCallbacks,
+  stopped: () => boolean,
+): Promise<void> {
+  if (stopped()) return;
+
+  const bot = new TelegramBot(token, { polling: true });
+  currentBot = bot;
+
+  // Verify the token by fetching bot identity. If it fails, surface the error
+  // and tear down — node-telegram-bot-api otherwise spins forever on 401s.
+  try {
+    const me = await bot.getMe();
+    callbacks.onLog(`[telegram] connected as @${me.username}`);
+    callbacks.onStatus("connected");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    callbacks.onLog(`[telegram] auth failed: ${msg}`);
+    callbacks.onStatus("error");
+    try {
+      await bot.stopPolling();
+    } catch {
+      /* ignore */
+    }
+    currentBot = null;
+    throw err;
+  }
+
+  bot.on("polling_error", (err) => {
+    callbacks.onLog(`[telegram] polling error: ${err.message}`);
+  });
+
+  onReady(bot);
+}
+
+export async function stopTelegramClient(): Promise<void> {
+  if (!currentBot) return;
+  try {
+    await currentBot.stopPolling({ cancel: true });
+  } catch {
+    /* ignore */
+  }
+  currentBot = null;
+}
+
+/**
+ * Proactively send a Telegram message without an incoming trigger.
+ * Used to forward async Manager notifications back to the trusted chat.
+ */
+export async function sendProactiveTelegram(
+  chatId: string | number,
+  text: string,
+  messageThreadId?: number,
+): Promise<void> {
+  if (!currentBot) throw new Error("Telegram not connected");
+  const { sendReply } = await import("./sender.js");
+  await sendReply(currentBot, Number(chatId), text, messageThreadId);
+}

--- a/packages/gateway/src/telegram/handler.ts
+++ b/packages/gateway/src/telegram/handler.ts
@@ -1,0 +1,59 @@
+import type TelegramBot from "node-telegram-bot-api";
+import { sendReply, startTyping } from "./sender.js";
+
+function isTrusted(chatId: number, trustedChatId: string): boolean {
+  if (!trustedChatId) return false;
+  return String(chatId) === trustedChatId.trim();
+}
+
+export function createMessageHandler(
+  bot: TelegramBot,
+  getTrustedChatId: () => string,
+  onMessage: (
+    from: string,
+    text: string,
+    messageThreadId?: number,
+  ) => Promise<string>,
+  onLog: (line: string) => void,
+) {
+  return async (msg: TelegramBot.Message) => {
+    const chatId = msg.chat.id;
+    const threadId = msg.message_thread_id;
+    const text = (msg.text ?? "").trim();
+    if (!text) return;
+
+    if (!isTrusted(chatId, getTrustedChatId())) {
+      onLog(`[telegram] blocked: chat ${chatId}`);
+      return;
+    }
+
+    const threadTag = threadId ? ` (topic ${threadId})` : "";
+    onLog(
+      `[telegram] message from ${chatId}${threadTag}: ${text.slice(0, 80)}`,
+    );
+
+    if (text === "/help" || text === "/start") {
+      await sendReply(
+        bot,
+        chatId,
+        "Anything you send here is forwarded to your Stratos Manager.",
+        threadId,
+      );
+      return;
+    }
+
+    await startTyping(bot, chatId, threadId);
+    try {
+      const reply = await onMessage(String(chatId), text, threadId);
+      await sendReply(bot, chatId, reply, threadId);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      onLog(`[telegram] error: ${errMsg}`);
+      const errReply =
+        errMsg.includes("socket") || errMsg.includes("connect")
+          ? "Stratos appears to be offline. Start it and try again."
+          : `Error: ${errMsg}`;
+      await sendReply(bot, chatId, errReply, threadId);
+    }
+  };
+}

--- a/packages/gateway/src/telegram/index.ts
+++ b/packages/gateway/src/telegram/index.ts
@@ -1,0 +1,64 @@
+import {
+  startTelegramBot,
+  stopTelegramClient,
+  sendProactiveTelegram,
+} from "./client.js";
+import { createMessageHandler } from "./handler.js";
+
+export interface TelegramGatewayConfig {
+  botToken: string;
+  trustedChatId: string;
+}
+
+export interface TelegramGatewayCallbacks {
+  onStatus(status: "connected" | "disconnected" | "error"): void;
+  onLog(line: string): void;
+  onMessage(
+    from: string,
+    text: string,
+    messageThreadId?: number,
+  ): Promise<string>;
+}
+
+let stopped = false;
+let liveConfig: TelegramGatewayConfig | null = null;
+
+/** Update the trusted chat id in the running gateway without reconnecting. */
+export function updateGatewayTrustedChatId(trustedChatId: string): void {
+  if (liveConfig) liveConfig.trustedChatId = trustedChatId;
+}
+
+export async function startTelegramGateway(
+  config: TelegramGatewayConfig,
+  callbacks: TelegramGatewayCallbacks,
+): Promise<void> {
+  stopped = false;
+  liveConfig = config;
+
+  await startTelegramBot(
+    config.botToken,
+    (bot) => {
+      const handler = createMessageHandler(
+        bot,
+        () => liveConfig?.trustedChatId ?? config.trustedChatId,
+        callbacks.onMessage,
+        callbacks.onLog,
+      );
+      bot.on("message", handler);
+      callbacks.onLog("[telegram] ready — waiting for messages");
+    },
+    {
+      onStatus: callbacks.onStatus,
+      onLog: callbacks.onLog,
+    },
+    () => stopped,
+  );
+}
+
+export async function stopTelegramGateway(): Promise<void> {
+  stopped = true;
+  liveConfig = null;
+  await stopTelegramClient();
+}
+
+export { sendProactiveTelegram };

--- a/packages/gateway/src/telegram/sender.ts
+++ b/packages/gateway/src/telegram/sender.ts
@@ -1,0 +1,50 @@
+import type TelegramBot from "node-telegram-bot-api";
+
+const MAX_CHUNK = 4000;
+
+function chunk(text: string): string[] {
+  if (text.length <= MAX_CHUNK) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > MAX_CHUNK) {
+    let cut = remaining.lastIndexOf("\n", MAX_CHUNK);
+    if (cut < MAX_CHUNK * 0.5) cut = MAX_CHUNK;
+    chunks.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+export async function sendReply(
+  bot: TelegramBot,
+  chatId: number,
+  text: string,
+  messageThreadId?: number,
+): Promise<void> {
+  const parts = chunk(text);
+  const opts: TelegramBot.SendMessageOptions | undefined = messageThreadId
+    ? { message_thread_id: messageThreadId }
+    : undefined;
+  for (let i = 0; i < parts.length; i++) {
+    const msg =
+      parts.length > 1 ? `(${i + 1}/${parts.length})\n${parts[i]}` : parts[i];
+    await bot.sendMessage(chatId, msg, opts);
+  }
+}
+
+export async function startTyping(
+  bot: TelegramBot,
+  chatId: number,
+  messageThreadId?: number,
+): Promise<void> {
+  try {
+    await bot.sendChatAction(
+      chatId,
+      "typing",
+      messageThreadId ? { message_thread_id: messageThreadId } : undefined,
+    );
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/packages/ui/src/bridges/StratosProvider.tsx
+++ b/packages/ui/src/bridges/StratosProvider.tsx
@@ -6,6 +6,7 @@ import type {
   PreviewBridge,
   FilesBridge,
   WhatsAppBridge,
+  TelegramBridge,
 } from "./types";
 
 export interface StratosContextValue {
@@ -15,6 +16,7 @@ export interface StratosContextValue {
   preview?: PreviewBridge;
   files?: FilesBridge;
   whatsapp?: WhatsAppBridge;
+  telegram?: TelegramBridge;
 }
 
 const StratosContext = createContext<StratosContextValue | null>(null);
@@ -61,4 +63,8 @@ export function useFilesBridge(): FilesBridge | undefined {
 
 export function useWhatsAppBridge(): WhatsAppBridge | undefined {
   return useStratos().whatsapp;
+}
+
+export function useTelegramBridge(): TelegramBridge | undefined {
+  return useStratos().telegram;
 }

--- a/packages/ui/src/bridges/types.ts
+++ b/packages/ui/src/bridges/types.ts
@@ -136,6 +136,28 @@ export interface WhatsAppBridge {
   onLog(cb: (line: string) => void): () => void;
 }
 
+export type TelegramStatus =
+  | "connected"
+  | "disconnected"
+  | "connecting"
+  | "error";
+
+export interface TelegramBridge {
+  getState(): Promise<{
+    status: TelegramStatus;
+    botTokenSet: boolean;
+    trustedChatId: string;
+  }>;
+  connect(): Promise<{ ok: boolean; error?: string }>;
+  disconnect(): Promise<{ ok: boolean }>;
+  saveSettings(s: {
+    botToken?: string;
+    trustedChatId?: string;
+  }): Promise<{ ok: boolean }>;
+  onStatus(cb: (status: TelegramStatus) => void): () => void;
+  onLog(cb: (line: string) => void): () => void;
+}
+
 export interface FilesBridge {
   listDirectory(dirPath: string, rootPath: string): Promise<DirEntry[]>;
   readFile(

--- a/packages/ui/src/components/TelegramSettings.tsx
+++ b/packages/ui/src/components/TelegramSettings.tsx
@@ -1,0 +1,527 @@
+import { useEffect, useRef, useState } from "react";
+import { useTelegramBridge } from "../bridges/StratosProvider";
+import type { TelegramStatus } from "../bridges/types";
+
+const TG_BLUE = "#229ED9";
+const TG_BLUE_DARK = "#1B7CB3";
+
+const CHAT_ID_RE = /^-?\d{5,}$/;
+const BOT_TOKEN_RE = /^\d{5,}:[A-Za-z0-9_-]{30,}$/;
+
+function isValidChatId(v: string): boolean {
+  return CHAT_ID_RE.test(v.trim());
+}
+
+function isValidToken(v: string): boolean {
+  return BOT_TOKEN_RE.test(v.trim());
+}
+
+function TgIcon({ size = 40 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="20" cy="20" r="20" fill={TG_BLUE} />
+      <path
+        fill="#fff"
+        d="M28.51 12.05L25.6 27.1c-.22 1-.81 1.24-1.64.77l-4.53-3.34-2.19 2.1c-.24.24-.45.45-.92.45l.33-4.66 8.48-7.66c.37-.32-.08-.51-.57-.18l-10.48 6.6-4.52-1.41c-.98-.31-1-.98.21-1.45l17.66-6.81c.82-.3 1.54.19 1.27 1.45z"
+      />
+    </svg>
+  );
+}
+
+function ConnectedPanel({
+  onDisconnect,
+  busy,
+}: {
+  onDisconnect: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div
+      className="rounded-xl flex items-center gap-4"
+      style={{
+        background: "var(--bg-surface)",
+        border: `1px solid ${TG_BLUE}33`,
+        padding: "16px 20px",
+      }}
+    >
+      <div
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: "50%",
+          background: `${TG_BLUE}22`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <TgIcon size={28} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="font-semibold text-sm" style={{ color: "var(--text)" }}>
+          Telegram Connected
+        </div>
+        <div className="text-xs" style={{ color: TG_BLUE, marginTop: 2 }}>
+          ● Active
+        </div>
+      </div>
+      <button
+        onClick={onDisconnect}
+        disabled={busy}
+        className="text-sm font-medium rounded-lg px-3 py-1.5"
+        style={{
+          background: "#ef444422",
+          color: "#ef4444",
+          border: "1px solid #ef444433",
+          opacity: busy ? 0.5 : 1,
+          cursor: busy ? "not-allowed" : "pointer",
+          flexShrink: 0,
+        }}
+      >
+        {busy ? "…" : "Disconnect"}
+      </button>
+    </div>
+  );
+}
+
+function DisconnectedPanel({
+  onConnect,
+  busy,
+  status,
+  canConnect,
+}: {
+  onConnect: () => void;
+  busy: boolean;
+  status: TelegramStatus;
+  canConnect: boolean;
+}) {
+  const subtitle =
+    status === "error"
+      ? "Connection failed — check the bot token below."
+      : status === "connecting"
+        ? "Connecting…"
+        : canConnect
+          ? "Message your Stratos Manager directly from Telegram."
+          : "Paste a bot token below, then connect.";
+
+  return (
+    <div
+      className="rounded-xl flex flex-col items-center text-center"
+      style={{
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        padding: "28px 24px",
+        gap: 12,
+      }}
+    >
+      <div
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: "50%",
+          background: `${TG_BLUE}18`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <TgIcon size={36} />
+      </div>
+      <div>
+        <div
+          className="font-semibold"
+          style={{ fontSize: 15, color: "var(--text)" }}
+        >
+          Connect Telegram
+        </div>
+        <div
+          className="text-xs"
+          style={{
+            color: status === "error" ? "#ef4444" : "var(--text-muted)",
+            marginTop: 4,
+            lineHeight: 1.5,
+          }}
+        >
+          {subtitle}
+        </div>
+      </div>
+      <button
+        onClick={onConnect}
+        disabled={busy || !canConnect || status === "connecting"}
+        className="rounded-xl text-sm font-semibold px-6 py-2.5"
+        style={{
+          background:
+            busy || !canConnect
+              ? "var(--text-muted)"
+              : `linear-gradient(135deg, ${TG_BLUE}, ${TG_BLUE_DARK})`,
+          color: "#fff",
+          opacity: busy || !canConnect ? 0.6 : 1,
+          cursor: busy || !canConnect ? "not-allowed" : "pointer",
+          border: "none",
+          marginTop: 4,
+          boxShadow: busy || !canConnect ? "none" : `0 2px 12px ${TG_BLUE}44`,
+        }}
+      >
+        {busy || status === "connecting" ? "Connecting…" : "Connect"}
+      </button>
+    </div>
+  );
+}
+
+function BotTokenEditor({
+  isSet,
+  onSave,
+}: {
+  isSet: boolean;
+  onSave: (token: string) => void;
+}) {
+  const [input, setInput] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  function handleSave() {
+    const val = input.trim();
+    if (!val) {
+      onSave("");
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+      return;
+    }
+    if (!isValidToken(val)) {
+      setInputError("Token format: 123456789:ABCdef…");
+      return;
+    }
+    setInputError(null);
+    onSave(val);
+    setInput("");
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === "Escape") {
+      setInput("");
+      setInputError(null);
+    }
+  }
+
+  function handleInputChange(val: string) {
+    setInput(val);
+    if (val.trim() && !isValidToken(val)) {
+      setInputError("Token format: 123456789:ABCdef…");
+    } else {
+      setInputError(null);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <label
+        className="text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--text-muted)" }}
+      >
+        Bot Token
+        {isSet && (
+          <span
+            style={{
+              marginLeft: 8,
+              color: TG_BLUE,
+              textTransform: "none",
+              fontSize: 10,
+              fontWeight: 500,
+            }}
+          >
+            ● set
+          </span>
+        )}
+      </label>
+      <div style={{ display: "flex", gap: 6 }}>
+        <input
+          type="password"
+          value={input}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            isSet ? "•••••• (replace existing)" : "123456789:ABCdef…"
+          }
+          autoComplete="off"
+          spellCheck={false}
+          className="text-sm font-mono rounded-lg px-3"
+          style={{
+            flex: 1,
+            height: 34,
+            background: "var(--bg-root)",
+            border: `1px solid ${inputError ? "#ef4444" : "var(--border)"}`,
+            color: "var(--text)",
+            outline: "none",
+          }}
+        />
+        <button
+          onClick={handleSave}
+          disabled={input.trim().length === 0 && !saved}
+          className="text-sm font-semibold rounded-lg px-3"
+          style={{
+            background: saved
+              ? "#22c55e"
+              : input.trim()
+                ? TG_BLUE
+                : "var(--bg-root)",
+            color: saved || input.trim() ? "#fff" : "var(--text-muted)",
+            border: `1px solid ${
+              saved ? "#22c55e" : input.trim() ? TG_BLUE : "var(--border)"
+            }`,
+            cursor: input.trim() ? "pointer" : "default",
+            height: 34,
+            flexShrink: 0,
+            transition: "background 0.2s, color 0.2s",
+          }}
+        >
+          {saved ? "Saved ✓" : "Save"}
+        </button>
+      </div>
+      {inputError ? (
+        <span className="text-xs" style={{ color: "#ef4444" }}>
+          {inputError}
+        </span>
+      ) : (
+        <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+          Get one from @BotFather. Saving a new token replaces the existing one.
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ChatIdEditor({
+  chatId,
+  onSave,
+}: {
+  chatId: string;
+  onSave: (id: string) => void;
+}) {
+  const [input, setInput] = useState(chatId);
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setInput(chatId);
+  }, [chatId]);
+
+  function handleSave() {
+    const val = input.trim();
+    if (!val) {
+      onSave("");
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+      return;
+    }
+    if (!isValidChatId(val)) {
+      setInputError("Numeric chat ID, e.g. 123456789");
+      return;
+    }
+    setInputError(null);
+    onSave(val);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === "Escape") {
+      setInput(chatId);
+      setInputError(null);
+    }
+  }
+
+  function handleInputChange(val: string) {
+    setInput(val);
+    if (val.trim() && !isValidChatId(val)) {
+      setInputError("Numeric chat ID, e.g. 123456789");
+    } else {
+      setInputError(null);
+    }
+  }
+
+  const isDirty = input.trim() !== chatId.trim();
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <label
+        className="text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--text-muted)" }}
+      >
+        Trusted Chat ID
+      </label>
+      <div style={{ display: "flex", gap: 6 }}>
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="123456789"
+          inputMode="numeric"
+          className="text-sm font-mono rounded-lg px-3"
+          style={{
+            flex: 1,
+            height: 34,
+            background: "var(--bg-root)",
+            border: `1px solid ${inputError ? "#ef4444" : "var(--border)"}`,
+            color: "var(--text)",
+            outline: "none",
+          }}
+        />
+        <button
+          onClick={handleSave}
+          disabled={!isDirty && !saved}
+          className="text-sm font-semibold rounded-lg px-3"
+          style={{
+            background: saved
+              ? "#22c55e"
+              : isDirty
+                ? TG_BLUE
+                : "var(--bg-root)",
+            color: saved || isDirty ? "#fff" : "var(--text-muted)",
+            border: `1px solid ${
+              saved ? "#22c55e" : isDirty ? TG_BLUE : "var(--border)"
+            }`,
+            cursor: isDirty ? "pointer" : "default",
+            height: 34,
+            flexShrink: 0,
+            transition: "background 0.2s, color 0.2s",
+          }}
+        >
+          {saved ? "Saved ✓" : "Save"}
+        </button>
+      </div>
+      {inputError ? (
+        <span className="text-xs" style={{ color: "#ef4444" }}>
+          {inputError}
+        </span>
+      ) : (
+        <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+          Only messages from this chat are forwarded. Send /start to your bot,
+          then check the gateway log to find your chat ID.
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function TelegramSettings(): React.ReactElement {
+  const bridge = useTelegramBridge();
+  const [status, setStatus] = useState<TelegramStatus>("disconnected");
+  const [botTokenSet, setBotTokenSet] = useState(false);
+  const [trustedChatId, setTrustedChatId] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!bridge) return;
+    bridge.getState().then((s) => {
+      setStatus(s.status);
+      setBotTokenSet(s.botTokenSet);
+      setTrustedChatId(s.trustedChatId);
+    });
+    const unStatus = bridge.onStatus(setStatus);
+    return () => {
+      unStatus();
+    };
+  }, [bridge]);
+
+  if (!bridge)
+    return (
+      <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+        Telegram gateway not available.
+      </p>
+    );
+
+  async function handleConnect() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await bridge!.connect();
+      if (!result.ok) setError(result.error ?? "Failed to connect");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    setBusy(true);
+    setError(null);
+    try {
+      await bridge!.disconnect();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleTokenSave(token: string) {
+    await bridge!.saveSettings({ botToken: token }).catch(console.error);
+    setBotTokenSet(Boolean(token));
+  }
+
+  async function handleChatIdSave(chatId: string) {
+    setTrustedChatId(chatId);
+    await bridge!.saveSettings({ trustedChatId: chatId }).catch(console.error);
+  }
+
+  const canConnect = botTokenSet;
+
+  return (
+    <div className="space-y-4">
+      {status === "connected" ? (
+        <ConnectedPanel onDisconnect={handleDisconnect} busy={busy} />
+      ) : (
+        <DisconnectedPanel
+          onConnect={handleConnect}
+          busy={busy}
+          status={status}
+          canConnect={canConnect}
+        />
+      )}
+
+      {error && (
+        <div
+          className="text-xs rounded-xl px-4 py-3"
+          style={{
+            background: "#3b000088",
+            color: "#fca5a5",
+            border: "1px solid #ef444444",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div
+        className="rounded-xl"
+        style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border)",
+          padding: "14px 16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        <BotTokenEditor isSet={botTokenSet} onSave={handleTokenSave} />
+        <ChatIdEditor chatId={trustedChatId} onSave={handleChatIdSave} />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -47,6 +47,8 @@ export {
   useSettingsBridge,
   usePreviewBridge,
   useFilesBridge,
+  useWhatsAppBridge,
+  useTelegramBridge,
 } from "./bridges/StratosProvider";
 export type { StratosContextValue } from "./bridges/StratosProvider";
 export type {
@@ -57,12 +59,15 @@ export type {
   FilesBridge,
   WhatsAppBridge,
   WhatsAppStatus,
+  TelegramBridge,
+  TelegramStatus,
   DirEntry,
   StreamEvent,
   ImageAttachment as BridgeImageAttachment,
   McpServerInfo,
 } from "./bridges/types";
 export { WhatsAppSettings } from "./components/WhatsAppSettings";
+export { TelegramSettings } from "./components/TelegramSettings";
 
 // Theme
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
         version: 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      node-telegram-bot-api:
+        specifier: ^0.66.0
+        version: 0.66.0(request@2.88.2)
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -204,6 +207,9 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.3.3
+      '@types/node-telegram-bot-api':
+        specifier: ^0.64.7
+        version: 0.64.14
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -482,6 +488,16 @@ packages:
 
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+
+  '@cypress/request-promise@5.0.0':
+    resolution: {integrity: sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      '@cypress/request': ^3.0.0
+
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
+    engines: {node: '>= 6'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -1515,6 +1531,9 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1654,6 +1673,9 @@ packages:
   '@types/node-cron@3.0.11':
     resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
+  '@types/node-telegram-bot-api@0.64.14':
+    resolution: {integrity: sha512-Nq1LAAw4PGpR8Vii5F7uGlAaAFmaT3cPIt7mUZv6VrftPsrt9xjmnhXD9hoKFstAzn/a5ZCr+ksbkmK+QBhZiA==}
+
   '@types/node@24.11.0':
     resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
 
@@ -1680,8 +1702,14 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1931,6 +1959,21 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findindex@2.2.4:
+    resolution: {integrity: sha512-LLm4mhxa9v8j0A/RPnpQAP4svXToJFh+Hp1pNYl5ZD5qpB4zdx/D4YjpVcETkhFbUKWO3iGMVLvrOnnmkAJT6A==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
@@ -1946,6 +1989,10 @@ packages:
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
@@ -1974,6 +2021,16 @@ packages:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
     engines: {node: '>=14'}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1992,8 +2049,17 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bl@1.2.3:
+    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -2065,6 +2131,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -2079,6 +2149,9 @@ packages:
 
   caniuse-lite@1.0.30001776:
     resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2428,8 +2501,32 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2537,6 +2634,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2617,6 +2717,10 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2634,6 +2738,14 @@ packages:
 
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
   es6-error@4.1.1:
@@ -2729,6 +2841,9 @@ packages:
   eventemitter3@2.0.3:
     resolution: {integrity: sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==}
 
+  eventemitter3@3.1.2:
+    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2769,6 +2884,10 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
@@ -2808,6 +2927,10 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
+  file-type@3.9.0:
+    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
+    engines: {node: '>=0.10.0'}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -2834,9 +2957,24 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -2889,6 +3027,17 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2912,6 +3061,13 @@ packages:
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2956,12 +3112,29 @@ packages:
     resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
 
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3031,6 +3204,14 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
@@ -3090,6 +3271,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
@@ -3111,8 +3296,36 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -3121,6 +3334,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -3128,6 +3345,10 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -3140,6 +3361,18 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3151,9 +3384,54 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
@@ -3169,6 +3447,9 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -3192,6 +3473,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3213,6 +3497,9 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3229,6 +3516,14 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
 
   katex@0.16.44:
     resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
@@ -3595,6 +3890,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
@@ -3730,6 +4030,10 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  node-telegram-bot-api@0.66.0:
+    resolution: {integrity: sha512-s4Hrg5q+VPl4/tJVG++pImxF6eb8tNJNj4KnDqAOKL6zGU34lo9RXmyAN158njwGN+v8hdNf8s9fWIYW9hPb5A==}
+    engines: {node: '>=0.12'}
+
   node-wav@0.0.2:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
@@ -3743,6 +4047,9 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3753,6 +4060,10 @@ packages:
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
@@ -3793,6 +4104,10 @@ packages:
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -3879,6 +4194,9 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3921,6 +4239,10 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3951,6 +4273,9 @@ packages:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -3979,6 +4304,12 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  pump@2.0.1:
+    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3998,9 +4329,20 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
+    engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -4064,6 +4406,9 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -4076,8 +4421,16 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -4095,6 +4448,17 @@ packages:
     resolution: {integrity: sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==}
     engines: {node: '>= 0.8.0'}
 
+  request-promise-core@1.1.3:
+    resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      request: ^2.34
+
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4105,6 +4469,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -4162,8 +4529,23 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -4212,6 +4594,18 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4309,6 +4703,11 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4330,6 +4729,14 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stealthy-require@1.1.1:
+    resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
+    engines: {node: '>=0.10.0'}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -4349,6 +4756,21 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4435,6 +4857,13 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
@@ -4453,6 +4882,18 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4478,6 +4919,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo-darwin-64@2.8.13:
     resolution: {integrity: sha512-PmOvodQNiOj77+Zwoqku70vwVjKzL34RTNxxoARjp5RU5FOj/CGiC6vcDQhNtFPUOWSAaogHF5qIka9TBhX4XA==}
@@ -4513,6 +4957,9 @@ packages:
     resolution: {integrity: sha512-nyM99hwFB9/DHaFyKEqatdayGjsMNYsQ/XBNO6MITc7roncZetKb97MpHxWf3uiU+LB9c9HUlU3Jp2Ixei2k1A==}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4524,6 +4971,22 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
 
   typescript-eslint@8.56.1:
     resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
@@ -4543,6 +5006,10 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -4580,6 +5047,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4597,6 +5068,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -4607,9 +5081,23 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -4725,8 +5213,24 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5069,6 +5573,37 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@chevrotain/utils@11.1.2': {}
+
+  '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(request@2.88.2)':
+    dependencies:
+      '@cypress/request': 3.0.10
+      bluebird: 3.7.2
+      request-promise-core: 1.1.3(request@2.88.2)
+      stealthy-require: 1.1.1
+      tough-cookie: 4.1.4
+    transitivePeerDependencies:
+      - request
+
+  '@cypress/request@3.0.10':
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 4.0.5
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      performance-now: 2.1.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      tough-cookie: 5.1.2
+      tunnel-agent: 0.6.0
+      uuid: 8.3.2
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -5921,6 +6456,8 @@ snapshots:
       '@types/node': 25.3.3
       '@types/responselike': 1.0.3
 
+  '@types/caseless@0.12.5': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6085,6 +6622,11 @@ snapshots:
 
   '@types/node-cron@3.0.11': {}
 
+  '@types/node-telegram-bot-api@0.64.14':
+    dependencies:
+      '@types/node': 25.3.3
+      '@types/request': 2.48.13
+
   '@types/node@24.11.0':
     dependencies:
       undici-types: 7.16.0
@@ -6117,9 +6659,18 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 25.3.3
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
+
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 25.3.3
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -6451,8 +7002,35 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  assert-plus@1.0.0:
-    optional: true
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array.prototype.findindex@2.2.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -6460,6 +7038,8 @@ snapshots:
     optional: true
 
   async-exit-hook@2.0.1: {}
+
+  async-function@1.0.0: {}
 
   async-mutex@0.5.0:
     dependencies:
@@ -6491,6 +7071,14 @@ snapshots:
   audio-type@2.4.1:
     optional: true
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -6501,11 +7089,22 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  bl@1.2.3:
+    dependencies:
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bluebird@3.7.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -6630,6 +7229,13 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6640,6 +7246,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001776: {}
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -6769,8 +7377,7 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  core-util-is@1.0.2:
-    optional: true
+  core-util-is@1.0.2: {}
 
   cors@2.8.6:
     dependencies:
@@ -6989,7 +7596,33 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   dayjs@1.11.20: {}
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -7023,14 +7656,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   delaunator@5.1.0:
     dependencies:
@@ -7104,6 +7735,11 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   ee-first@1.1.1: {}
 
@@ -7213,6 +7849,63 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -7229,6 +7922,16 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es6-error@4.1.1:
     optional: true
@@ -7390,6 +8093,8 @@ snapshots:
 
   eventemitter3@2.0.3: {}
 
+  eventemitter3@3.1.2: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -7454,8 +8159,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extsprintf@1.4.1:
-    optional: true
+  extsprintf@1.3.0: {}
+
+  extsprintf@1.4.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7489,6 +8195,8 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+
+  file-type@3.9.0: {}
 
   filelist@1.0.6:
     dependencies:
@@ -7526,10 +8234,31 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  forever-agent@0.6.1: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
 
   form-data@4.0.5:
     dependencies:
@@ -7587,6 +8316,19 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -7614,6 +8356,16 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   glob-parent@6.0.2:
     dependencies:
@@ -7653,7 +8405,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -7687,12 +8438,24 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.14.0
+      har-schema: 2.0.0
+
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -7783,6 +8546,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
   http2-wrapper@1.0.3:
     dependencies:
       quick-lru: 5.1.1
@@ -7835,6 +8610,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
@@ -7850,17 +8631,65 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-buffer@1.1.6: {}
+
+  is-callable@1.2.7: {}
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.5.0
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -7870,13 +8699,67 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-typedarray@1.0.0: {}
+
   is-unicode-supported@0.1.0: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
 
   isbinaryfile@4.0.10: {}
 
@@ -7885,6 +8768,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  isstream@0.1.2: {}
 
   jackspeak@3.4.3:
     dependencies:
@@ -7908,6 +8793,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7923,10 +8810,11 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -7939,6 +8827,20 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   katex@0.16.44:
     dependencies:
@@ -8529,6 +9431,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mime@2.6.0: {}
 
   mimic-fn@2.1.0: {}
@@ -8673,6 +9577,21 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  node-telegram-bot-api@0.66.0(request@2.88.2):
+    dependencies:
+      '@cypress/request': 3.0.10
+      '@cypress/request-promise': 5.0.0(@cypress/request@3.0.10)(request@2.88.2)
+      array.prototype.findindex: 2.2.4
+      bl: 1.2.3
+      debug: 3.2.7
+      eventemitter3: 3.1.2
+      file-type: 3.9.0
+      mime: 1.6.0
+      pump: 2.0.1
+    transitivePeerDependencies:
+      - request
+      - supports-color
+
   node-wav@0.0.2:
     optional: true
 
@@ -8682,12 +9601,22 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  oauth-sign@0.9.0: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   obug@2.1.1: {}
 
@@ -8746,6 +9675,12 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   p-cancelable@2.1.1: {}
 
@@ -8817,6 +9752,8 @@ snapshots:
 
   pend@1.2.0: {}
 
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -8866,6 +9803,8 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -8890,6 +9829,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   proc-log@5.0.0: {}
+
+  process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
 
@@ -8934,6 +9875,15 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  pump@2.0.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -8956,9 +9906,17 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.5.5: {}
+
+  querystringify@2.2.0: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -9032,6 +9990,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -9045,12 +10013,32 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   refractor@5.0.0:
     dependencies:
       '@types/hast': 3.0.4
       '@types/prismjs': 1.26.6
       hastscript: 9.0.1
       parse-entities: 4.0.2
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   remark-gfm@4.0.1:
     dependencies:
@@ -9088,11 +10076,41 @@ snapshots:
 
   rename-keys@1.2.0: {}
 
+  request-promise-core@1.1.3(request@2.88.2):
+    dependencies:
+      lodash: 4.18.1
+      request: 2.88.2
+
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
+
+  requires-port@1.0.0: {}
 
   resedit@1.7.2:
     dependencies:
@@ -9186,7 +10204,28 @@ snapshots:
 
   rw@1.3.3: {}
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
 
@@ -9240,6 +10279,28 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
 
@@ -9373,6 +10434,18 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
@@ -9386,6 +10459,13 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stealthy-require@1.1.1: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   string-argv@0.3.2: {}
 
@@ -9411,6 +10491,33 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -9505,6 +10612,12 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.5
@@ -9523,6 +10636,22 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -9540,6 +10669,10 @@ snapshots:
   ts-dedent@2.2.0: {}
 
   tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo-darwin-64@2.8.13:
     optional: true
@@ -9568,6 +10701,8 @@ snapshots:
       turbo-windows-64: 2.8.13
       turbo-windows-arm64: 2.8.13
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -9580,6 +10715,39 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
 
   typescript-eslint@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -9597,6 +10765,13 @@ snapshots:
   ufo@1.6.3: {}
 
   uint8array-extras@1.5.0: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@7.16.0: {}
 
@@ -9645,6 +10820,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -9659,13 +10836,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
 
+  uuid@3.4.0: {}
+
+  uuid@8.3.2: {}
+
   vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
 
   verror@1.10.1:
     dependencies:
@@ -9762,7 +10954,48 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
   which-module@2.0.1: {}
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds an in-process Telegram bridge that forwards messages to the Manager Agent and routes replies (including async child-completion notifications) back to the same chat — and same forum topic, when the chat has them.
- Mirrors the WhatsApp pattern end-to-end: same package layout, same flag-file gating (`~/.stratos/telegram.json`), same shared `gateway.log`, same tray-menu treatment, same Manager wiring (`sendFromGateway` + `setNotificationForward`).
- Setup walkthrough in `docs/telegram-integration.md` covers BotFather, finding your chat ID via the gateway log, forum-topic supergroups, and troubleshooting.

### Behavioral notes

- Auth verified up front via `getMe` so a bad token surfaces immediately instead of polling forever on a 401.
- Single trusted chat ID (parity with WhatsApp). Trusted-ID changes are live; bot-token swaps require disconnect/reconnect.
- `message_thread_id` is preserved through the handler, sender, and the proactive-notification path so forum topics thread cleanly. Plain DMs are unaffected.
- Manager remains a singleton — all Telegram topics share one Manager conversation. Topic only controls **where** the reply lands. This is documented in the integration doc.

## Test plan

- [ ] `pnpm install`, `pnpm build`, `pnpm -r typecheck`, `pnpm -r lint` — all clean (one pre-existing test failure on `main` for unrelated `mcp__stratos__` tool count drift).
- [ ] Without `~/.stratos/telegram.json`: Settings → Telegram section is hidden, tray menu has no Telegram entry, no IPC handlers registered.
- [ ] With the flag file present: Settings → Telegram appears, tray menu shows live status.
- [ ] Paste an invalid token → status flips to `error`, gateway log shows `auth failed`.
- [ ] Paste a valid token, save, click **Connect** → status `connected`, log shows `connected as @your_bot`.
- [ ] Send a message from a non-trusted chat → blocked, log entry only, no reply.
- [ ] Save trusted chat ID, send `/start` from that chat → bot replies with the help text.
- [ ] Send a real message → typing indicator appears, Manager replies, reply lands in the same chat.
- [ ] In a forum-topic supergroup, send a message inside a topic → reply (and any later async completion notification) lands inside the same topic, not General.
- [ ] Click **Disconnect** → status `disconnected`, polling stops, manager forward cleared.
- [ ] Quit the app → no orphaned processes, `unregisterTelegramIpc` runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)