### PR TITLE
Gateway reconnect resilience + preview-pane button on file changes

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1334,6 +1334,7 @@ function AppInner(): React.ReactElement {
                   filesBridge={filesBridge}
                   sessionChanges={sessionChanges}
                   gitStatus={gitStatus}
+                  onOpenArtifact={openArtifactEditor}
                 />
               </Panel>
             </>

--- a/packages/gateway/src/client.ts
+++ b/packages/gateway/src/client.ts
@@ -120,6 +120,10 @@ export function stopWhatsAppClient(): void {
   currentSock = null;
 }
 
+export function getCurrentSock(): WASocket | null {
+  return currentSock;
+}
+
 /**
  * Proactively send a WhatsApp message to a JID without an incoming trigger.
  * Used to forward async Manager notifications back to the last known sender.

--- a/packages/gateway/src/handler.ts
+++ b/packages/gateway/src/handler.ts
@@ -1,5 +1,5 @@
 import type { WASocket, BaileysEventMap } from "@whiskeysockets/baileys";
-import type { ResolveJid } from "./client.js";
+import { getCurrentSock, type ResolveJid } from "./client.js";
 import { sendReply, startTyping, stopTyping } from "./sender.js";
 
 type MessageUpsert = BaileysEventMap["messages.upsert"];
@@ -20,8 +20,19 @@ function isTrusted(jid: string, trustedPhone: string): boolean {
   return e164 === trusted || jid === trusted;
 }
 
+// Wait briefly for the WhatsApp socket to come back after a reconnect.
+// Returns the live sock or null if it never reappeared in time.
+async function waitForLiveSock(timeoutMs = 8000): Promise<WASocket | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const sock = getCurrentSock();
+    if (sock?.user) return sock;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return getCurrentSock();
+}
+
 export function createMessageHandler(
-  sock: WASocket,
   getTrustedPhone: () => string,
   resolveJid: ResolveJid,
   onMessage: (from: string, text: string) => Promise<string>,
@@ -47,28 +58,59 @@ export function createMessageHandler(
       onLog(`[handler] message from ${jid}: ${text.slice(0, 80)}`);
 
       if (text === "/help") {
-        await sendReply(
-          sock,
-          jid,
-          "Anything you send here is forwarded to your Stratos Manager.",
-        );
+        const sock = getCurrentSock();
+        if (sock) {
+          await sendReply(
+            sock,
+            jid,
+            "Anything you send here is forwarded to your Stratos Manager.",
+          );
+        }
         continue;
       }
 
-      await startTyping(sock, jid);
+      const startSock = getCurrentSock();
+      if (startSock) await startTyping(startSock, jid);
+
       try {
         const reply = await onMessage(jid, text);
+        const sock = getCurrentSock() ?? (await waitForLiveSock());
+        if (!sock) {
+          onLog(
+            `[handler] socket lost; could not deliver reply to ${jid}: ${reply.slice(0, 60)}`,
+          );
+          continue;
+        }
         await stopTyping(sock, jid);
-        await sendReply(sock, jid, reply);
+        try {
+          await sendReply(sock, jid, reply);
+        } catch (sendErr) {
+          // Connection may have just dropped; wait for reconnect and try once more.
+          const retrySock = await waitForLiveSock();
+          if (retrySock) {
+            await sendReply(retrySock, jid, reply);
+          } else {
+            const m =
+              sendErr instanceof Error ? sendErr.message : String(sendErr);
+            onLog(`[handler] reply send failed (no live socket): ${m}`);
+          }
+        }
       } catch (err) {
-        await stopTyping(sock, jid);
-        const msg2 = err instanceof Error ? err.message : String(err);
-        onLog(`[handler] error: ${msg2}`);
+        const m = err instanceof Error ? err.message : String(err);
+        onLog(`[handler] error: ${m}`);
         const errReply =
-          msg2.includes("socket") || msg2.includes("connect")
+          m.includes("socket") || m.includes("connect")
             ? "Stratos appears to be offline. Start it and try again."
-            : `Error: ${msg2}`;
-        await sendReply(sock, jid, errReply);
+            : `Error: ${m}`;
+        const sock = getCurrentSock() ?? (await waitForLiveSock());
+        if (sock) {
+          await stopTyping(sock, jid);
+          try {
+            await sendReply(sock, jid, errReply);
+          } catch {
+            /* swallow — already in error path */
+          }
+        }
       }
     }
   };

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -38,7 +38,6 @@ export async function startGateway(
     authDir,
     (sock, resolveJid) => {
       const handler = createMessageHandler(
-        sock,
         () => liveConfig?.trustedPhone ?? config.trustedPhone,
         resolveJid,
         callbacks.onMessage,

--- a/packages/ui/src/components/FileChangeViewer.tsx
+++ b/packages/ui/src/components/FileChangeViewer.tsx
@@ -19,6 +19,7 @@ interface Props {
   toolCall: ToolCall;
   defaultExpanded?: boolean;
   fillHeight?: boolean;
+  onPreview?: () => void;
 }
 
 const statusColors: Record<ToolCall["status"], string> = {
@@ -90,6 +91,7 @@ export function FileChangeViewer({
   toolCall,
   defaultExpanded = true,
   fillHeight = false,
+  onPreview,
 }: Props): React.ReactElement {
   useMonacoFontReady();
   const theme = useTheme();
@@ -340,13 +342,13 @@ export function FileChangeViewer({
       className={`rounded-lg bg-[var(--bg-overlay)] border border-[var(--border-mid)] overflow-hidden text-xs ${fillHeight ? "flex flex-col h-full" : ""}`}
     >
       {/* Header - always visible */}
-      <button
-        onClick={toggleExpand}
-        className="w-full p-3 flex items-center justify-between hover:bg-[var(--bg-surface)] transition-colors text-left"
-        aria-expanded={isExpanded}
-        aria-label={`${isExpanded ? "Collapse" : "Expand"} ${toolCall.toolName} for ${fileName}`}
-      >
-        <div className="flex items-center gap-2 min-w-0 flex-1">
+      <div className="w-full flex items-stretch">
+        <button
+          onClick={toggleExpand}
+          className="flex items-center gap-2 min-w-0 flex-1 p-3 hover:bg-[var(--bg-surface)] transition-colors text-left"
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} ${toolCall.toolName} for ${fileName}`}
+        >
           <span className="text-[var(--text-muted)] flex-shrink-0">
             {isExpanded ? "▾" : "▸"}
           </span>
@@ -366,13 +368,35 @@ export function FileChangeViewer({
               <span className="text-red-400">-{changeStats.removed}</span>
             </span>
           )}
+        </button>
+        <div className="flex items-center gap-2 pr-3 pl-1 flex-shrink-0">
+          {onPreview && (
+            <button
+              onClick={onPreview}
+              className="p-1 rounded hover:bg-[var(--border-mid)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+              title="Open file in preview pane"
+              aria-label="Open file in preview pane"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            </button>
+          )}
+          <span className={`text-xs ${statusColors[toolCall.status]}`}>
+            {statusLabels[toolCall.status]}
+          </span>
         </div>
-        <span
-          className={`text-xs ml-2 flex-shrink-0 ${statusColors[toolCall.status]}`}
-        >
-          {statusLabels[toolCall.status]}
-        </span>
-      </button>
+      </div>
 
       {/* Non-Monaco content (too large warning or loading placeholder) - safe to mount/unmount */}
       {isExpanded && (isTooLarge || !shouldRenderMonaco) && (

--- a/packages/ui/src/components/PreviewPane.tsx
+++ b/packages/ui/src/components/PreviewPane.tsx
@@ -15,6 +15,7 @@ interface Props {
   filesBridge?: FilesBridge;
   sessionChanges?: SessionChanges;
   gitStatus?: GitStatus;
+  onOpenArtifact?: (content: string, filePath: string) => void;
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -33,6 +34,7 @@ export function PreviewPane({
   filesBridge,
   sessionChanges,
   gitStatus,
+  onOpenArtifact,
 }: Props): React.ReactElement {
   const handleOpenExternal = (): void => {
     if (preview.url) {
@@ -168,7 +170,11 @@ export function PreviewPane({
           />
         </div>
       ) : preview.type === "file-changes" && sessionChanges ? (
-        <SessionChangesPane changes={sessionChanges} gitStatus={gitStatus} />
+        <SessionChangesPane
+          changes={sessionChanges}
+          gitStatus={gitStatus}
+          onOpenArtifact={onOpenArtifact}
+        />
       ) : preview.url ? (
         <WebviewPreview url={preview.url} />
       ) : null}

--- a/packages/ui/src/components/SessionChangesPane.tsx
+++ b/packages/ui/src/components/SessionChangesPane.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import type { SessionChanges } from "../hooks/useSessionChanges";
 import type { GitFileState, GitStatus } from "../types";
 import { FileChangeViewer } from "./FileChangeViewer";
 import { basename } from "../utils/path";
+import { useFilesBridge } from "../bridges/StratosProvider";
 
 interface Props {
   changes: SessionChanges;
   gitStatus?: GitStatus;
+  onOpenArtifact?: (content: string, filePath: string) => void;
 }
 
 const STATE_CONFIG: Record<
@@ -67,7 +69,9 @@ function getFileState(
 export function SessionChangesPane({
   changes,
   gitStatus,
+  onOpenArtifact,
 }: Props): React.ReactElement {
+  const filesBridge = useFilesBridge();
   const [selectedPath, setSelectedPath] = useState<string | null>(
     // Prefer the already-running file when the panel opens mid-run
     (changes.files.find((f) => f.hasRunning) ?? changes.files[0])?.filePath ??
@@ -115,6 +119,27 @@ export function SessionChangesPane({
     changes.files.find((f) => f.filePath === selectedPath) ??
     changes.files[0] ??
     null;
+
+  const selectedFilePath = selectedFile?.filePath ?? null;
+  const handlePreview = useCallback(async () => {
+    if (!selectedFilePath || !filesBridge || !onOpenArtifact) return;
+    const rootPath = gitStatus?.root;
+    if (!rootPath) return;
+    try {
+      const { content, isBinary } = await filesBridge.readFile(
+        selectedFilePath,
+        rootPath,
+      );
+      if (isBinary) return;
+      onOpenArtifact(content, selectedFilePath);
+    } catch (err) {
+      console.error("Failed to read file for preview:", err);
+    }
+  }, [selectedFilePath, filesBridge, onOpenArtifact, gitStatus?.root]);
+
+  const canPreview = Boolean(
+    onOpenArtifact && filesBridge && gitStatus?.root && selectedFilePath,
+  );
 
   if (changes.files.length === 0) {
     return (
@@ -225,6 +250,7 @@ export function SessionChangesPane({
               toolCall={selectedFile.latestToolCall}
               defaultExpanded={true}
               fillHeight={true}
+              onPreview={canPreview ? handlePreview : undefined}
             />
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

Two unrelated fixes/features that were sitting locally:

- **fix(gateway):** WhatsApp message handler now resolves the WASocket dynamically via `getCurrentSock()` on every send instead of capturing it once at construction. After a reconnect the captured reference was stale, so replies silently failed. Adds a short `waitForLiveSock` poll and a single retry on `sendReply` failure.
- **feat(ui):** Adds an eye-icon button next to the status label in `FileChangeViewer` that opens the selected file as an artifact in the preview pane. The header is split into a separate expand/collapse button and an actions strip so the new button doesn't toggle the diff. Wired through `PreviewPane` → `SessionChangesPane` → `FileChangeViewer` via a new `onOpenArtifact` callback.

## Test plan

- [ ] WhatsApp gateway: trigger a reconnect mid-handler (e.g. drop network briefly) and confirm the reply still arrives once the socket comes back
- [ ] WhatsApp gateway: with a healthy socket, normal replies and `/help` still work
- [ ] UI: open the Changes pane, hover a file, click the eye icon — the file opens in the preview pane as an artifact
- [ ] UI: clicking the eye icon does NOT toggle the diff expand/collapse
- [ ] UI: button is hidden when there's no `gitStatus.root` or no selected file
- [ ] CI: lint, typecheck, tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)