### PR TITLE
fix(provider): keep streaming-input prompt parked so CLI stdin stays open

### DIFF
--- a/packages/core/src/__tests__/claude-code.provider.integration.test.ts
+++ b/packages/core/src/__tests__/claude-code.provider.integration.test.ts
@@ -414,4 +414,189 @@ describe("ClaudeCodeProvider integration (fake SDK)", () => {
 
     expect(mockInterrupt).toHaveBeenCalled();
   });
+
+  describe("streaming-input prompt lifecycle", () => {
+    // Regression: the prompt generator handed to the SDK previously returned
+    // immediately after its one yield, causing the SDK transport to send
+    // stdin EOF to the Claude CLI subprocess mid-turn. The CLI would then set
+    // inputClosed=true, and every subsequent can_use_tool request from the
+    // CLI would synchronously fail with "Stream closed", surfacing in the UI
+    // as: "Tool permission request failed: Error: Stream closed".
+    //
+    // Fix: keep the generator parked on a Promise until the for-await loop
+    // on the output side terminates (success, error, or interrupt).
+
+    // Capture only the FIRST query() call (the per-turn streaming-input one).
+    // sendMessage also spins up a background control query at end-of-turn
+    // which would otherwise overwrite our capture.
+    function captureFirstPromptFromQuery() {
+      type AsyncIterableLike<T> = {
+        [Symbol.asyncIterator]: () => AsyncIterator<T>;
+      };
+      let captured: AsyncIterator<unknown> | undefined;
+      mockQuery.mockImplementation(
+        ({ prompt }: { prompt: AsyncIterableLike<unknown> }) => {
+          if (captured === undefined) {
+            captured = prompt[Symbol.asyncIterator]();
+          }
+          return makeStream([
+            {
+              type: "system",
+              subtype: "init",
+              session_id: "sess-stream",
+              tools: [],
+              slash_commands: [],
+            },
+          ]);
+        },
+      );
+      return () => captured;
+    }
+
+    it("prompt generator stays parked after yielding the user message", async () => {
+      const getGen = captureFirstPromptFromQuery();
+      const provider = new ClaudeCodeProvider();
+      await provider.initialize({});
+
+      // Drain the turn — the for-await loop runs, then its finally releases
+      // the parked generator. We inspect the generator state below.
+      await collectMessages(provider, "hi");
+
+      const gen = getGen();
+      expect(gen).toBeDefined();
+
+      // First yield: the initial user message.
+      const first = await gen!.next();
+      expect(first.done).toBe(false);
+      const value = first.value as {
+        type: string;
+        message: { content: unknown };
+      };
+      expect(value.type).toBe("user");
+      expect(value.message.content).toBe("hi");
+
+      // After the for-await finally released the park, the generator must
+      // complete on the next pull (rather than yielding another value).
+      const second = await gen!.next();
+      expect(second.done).toBe(true);
+    });
+
+    it("prompt generator does NOT complete before for-await loop finishes", async () => {
+      // Build an SDK stream that parks on its second event so the for-await
+      // loop in sendMessage stays live. The prompt generator must still be
+      // parked at that point — that's the entire point of the fix.
+      let resolveStream: (() => void) | undefined;
+      type AsyncIterableLike<T> = {
+        [Symbol.asyncIterator]: () => AsyncIterator<T>;
+      };
+      let capturedPrompt: AsyncIterator<unknown> | undefined;
+      mockQuery.mockImplementation(
+        ({ prompt }: { prompt: AsyncIterableLike<unknown> }) => {
+          if (capturedPrompt === undefined) {
+            capturedPrompt = prompt[Symbol.asyncIterator]();
+          }
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield {
+                type: "system",
+                subtype: "init",
+                session_id: "sess-park",
+                tools: [],
+                slash_commands: [],
+              };
+              await new Promise<void>((r) => {
+                resolveStream = r;
+              });
+            },
+            interrupt: vi.fn().mockResolvedValue(undefined),
+          };
+        },
+      );
+
+      const provider = new ClaudeCodeProvider();
+      await provider.initialize({});
+
+      const turn = provider.sendMessage({
+        prompt: "park me",
+        permissionHandler: autoApprove,
+      });
+
+      // Drive the outer generator past its first yield so the inner for-await
+      // is actively iterating the mocked SDK stream.
+      await turn.next();
+
+      // Consume the first yield from the prompt generator (the user message).
+      expect(capturedPrompt).toBeDefined();
+      const first = await capturedPrompt!.next();
+      expect(first.done).toBe(false);
+
+      // The second pull must hit `await parked` and remain pending because
+      // the for-await loop in sendMessage hasn't finished yet — its mocked
+      // SDK stream is suspended on resolveStream.
+      const nextP = capturedPrompt!.next();
+      const settled = await Promise.race([
+        nextP.then(() => "settled" as const),
+        new Promise<"pending">((r) => setTimeout(() => r("pending"), 50)),
+      ]);
+      expect(settled).toBe("pending");
+
+      // Release the inner SDK stream so the for-await loop can complete,
+      // which releases the parked generator.
+      resolveStream?.();
+      await turn.return?.(undefined);
+      // Await the parked next() so vitest doesn't flag an unhandled promise.
+      await nextP.catch(() => undefined);
+    });
+
+    it("interrupt releases the parked prompt generator", async () => {
+      let resolveStream: (() => void) | undefined;
+      type AsyncIterableLike<T> = {
+        [Symbol.asyncIterator]: () => AsyncIterator<T>;
+      };
+      let capturedPrompt: AsyncIterator<unknown> | undefined;
+      mockQuery.mockImplementation(
+        ({ prompt }: { prompt: AsyncIterableLike<unknown> }) => {
+          if (capturedPrompt === undefined) {
+            capturedPrompt = prompt[Symbol.asyncIterator]();
+          }
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield {
+                type: "system",
+                subtype: "init",
+                session_id: "sess-irq",
+                tools: [],
+                slash_commands: [],
+              };
+              await new Promise<void>((r) => {
+                resolveStream = r;
+              });
+            },
+            interrupt: vi.fn().mockResolvedValue(undefined),
+          };
+        },
+      );
+
+      const provider = new ClaudeCodeProvider();
+      await provider.initialize({});
+
+      const turn = provider.sendMessage({
+        prompt: "go",
+        permissionHandler: autoApprove,
+      });
+      await turn.next();
+      // Consume the first yield (the user message).
+      await capturedPrompt!.next();
+
+      // Calling interrupt() must release the parked generator without
+      // needing the for-await loop to drain.
+      await provider.interrupt();
+      const after = await capturedPrompt!.next();
+      expect(after.done).toBe(true);
+
+      // Clean up the test SDK stream so vitest doesn't hang.
+      resolveStream?.();
+      await turn.return?.(undefined);
+    });
+  });
 });

--- a/packages/core/src/providers/claude-code.provider.ts
+++ b/packages/core/src/providers/claude-code.provider.ts
@@ -123,6 +123,13 @@ export class ClaudeCodeProvider implements AgentProvider {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private controlQuery?: any;
   private controlCleanup?: () => void;
+  // Releases the parked streamingPrompt generator at end-of-turn so the SDK's
+  // stdin pipe stays open while the CLI is still emitting control_requests
+  // (can_use_tool, etc.). If the generator returned immediately after its one
+  // yield, the SDK would call stdin.end() on the CLI, the CLI would set
+  // inputClosed=true, and every subsequent canUseTool would synchronously
+  // fail with "Tool permission request failed: Error: Stream closed".
+  private releaseStreamingPrompt?: () => void;
   // Auto-close the control query after 5 minutes of inactivity. Each new turn
   // cancels and resets this timer. Prevents idle claude subprocesses from
   // accumulating when the user hasn't interacted with a thread for a while.
@@ -272,13 +279,30 @@ export class ClaudeCodeProvider implements AgentProvider {
     // Always use streaming-input mode so SDK control requests
     // (getContextUsage, interrupt, mcp toggles) remain available
     // throughout the turn — not just when MCP/images are involved.
+    //
+    // The generator must NOT return after the single yield: the SDK's
+    // transport closes stdin to the CLI subprocess as soon as the prompt
+    // generator is exhausted. Once the CLI sees stdin EOF it sets
+    // inputClosed=true, and every subsequent control_request it tries to
+    // send (notably can_use_tool) fails with "Stream closed", which the
+    // CLI surfaces back as a per-tool denial:
+    //     "Tool permission request failed: Error: Stream closed"
+    // To keep the pipe open for the entire turn, we park the generator on
+    // a Promise that resolves only when the for-await loop below finishes
+    // (success, error, or interrupt). See releaseStreamingPrompt.
+    this.releaseStreamingPrompt?.();
+    const parked = new Promise<void>((resolve) => {
+      this.releaseStreamingPrompt = resolve;
+    });
+    const initialMessage = {
+      type: "user" as const,
+      message: { role: "user" as const, content: messageContent },
+      parent_tool_use_id: null,
+      session_id: "",
+    };
     async function* streamingPrompt() {
-      yield {
-        type: "user" as const,
-        message: { role: "user" as const, content: messageContent },
-        parent_tool_use_id: null,
-        session_id: "",
-      };
+      yield initialMessage;
+      await parked;
     }
     this.currentQuery = query({ prompt: streamingPrompt(), options });
 
@@ -290,20 +314,29 @@ export class ClaudeCodeProvider implements AgentProvider {
       pendingToolIds: new Map<number, string>(),
     };
 
-    for await (const msg of this.currentQuery) {
-      if (params.traceCallback) {
-        params.traceCallback({
-          timestamp: Date.now(),
-          sessionId: this.sessionId,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          messageUuid: (msg as any).uuid,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          parentToolUseId: (msg as any).parent_tool_use_id,
-          messageType: msg.type,
-          data: truncateForTrace(msg),
-        });
+    try {
+      for await (const msg of this.currentQuery) {
+        if (params.traceCallback) {
+          params.traceCallback({
+            timestamp: Date.now(),
+            sessionId: this.sessionId,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            messageUuid: (msg as any).uuid,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            parentToolUseId: (msg as any).parent_tool_use_id,
+            messageType: msg.type,
+            data: truncateForTrace(msg),
+          });
+        }
+        yield* this.transformMessage(msg, streamCtx);
       }
-      yield* this.transformMessage(msg, streamCtx);
+    } finally {
+      // Release the parked generator so the SDK transport tears down cleanly.
+      // Must run on every exit path (normal completion, thrown error, or
+      // caller aborting the async iterator) — otherwise the generator stays
+      // suspended and the subprocess lingers.
+      this.releaseStreamingPrompt?.();
+      this.releaseStreamingPrompt = undefined;
     }
 
     // The turn is done — the query's transport is now closed.
@@ -431,6 +464,11 @@ export class ClaudeCodeProvider implements AgentProvider {
     ) {
       await this.currentQuery.interrupt();
     }
+    // Unblock the parked streamingPrompt generator so the SDK transport
+    // can tear down cleanly. The for-await loop's finally also handles
+    // this, but interrupt() may be called before/outside that scope.
+    this.releaseStreamingPrompt?.();
+    this.releaseStreamingPrompt = undefined;
   }
 
   canResume(sessionId: string): boolean {
@@ -709,6 +747,8 @@ export class ClaudeCodeProvider implements AgentProvider {
     this.closeControlQuery();
     this.sessionId = undefined;
     this.currentQuery = undefined;
+    this.releaseStreamingPrompt?.();
+    this.releaseStreamingPrompt = undefined;
   }
 
   private *transformMessage(


### PR DESCRIPTION
## Summary

Fixes #83.

Tool calls were intermittently failing with:

> `Tool permission request failed: Error: Stream closed`

…and once a thread hit that state, every subsequent tool failed the same way until the app was restarted. Bypass mode didn't help because the failure happens in the Claude CLI subprocess _before_ Stratos's `permissionHandler` is ever consulted.

The cause was the per-turn `streamingPrompt` generator returning after a single yield. The SDK transport then called `stdin.end()` on the CLI; the CLI marked `inputClosed=true`; and every subsequent `can_use_tool` request the CLI tried to send synchronously failed with `Stream closed`, which the CLI's own wrapper surfaced back as a per-tool denial. Detailed RC is in #83.

The control-query path (`ensureControlQuery → parkedPrompt`) already does the right thing — it parks the generator on a never-resolving Promise. This PR makes the per-turn streaming-input path follow the same pattern: park on a Promise that the for-await's `finally` releases at end-of-turn, and also release on `interrupt()` / `dispose()` so abort paths don't leak a suspended generator.

## Changes

- `packages/core/src/providers/claude-code.provider.ts`
  - New private field `releaseStreamingPrompt` to hold the parked-generator resolver.
  - `streamingPrompt` now awaits a parking Promise after its single yield.
  - `for await … of this.currentQuery` wrapped in `try { … } finally { release }` so every exit path tears down cleanly.
  - `interrupt()` and `dispose()` also release the park.
- `packages/core/src/__tests__/claude-code.provider.integration.test.ts`
  - Three new tests covering the lifecycle (`prompt generator stays parked after yielding the user message`, `prompt generator does NOT complete before for-await loop finishes`, `interrupt releases the parked prompt generator`).

## Test plan

- [x] `pnpm --filter @stratosapp/core test` → all 220 tests pass (15 in the modified integration file, including the 3 new ones).
- [x] `pnpm lint` → 0 errors.
- [x] `pnpm build` → clean (full typecheck via `tsc --noEmit`-equivalent).
- [x] `pnpm --filter @stratosapp/desktop test` → all 217 tests pass when run in isolation.
  - The pre-existing parallel-run flakes in `sdk-mcp-policy.integration.test.ts` etc. (6 failures on `main` baseline, identical set after this change) are unrelated.
- [x] **CDP smoke check**: ran `pnpm --filter @stratosapp/desktop dev:debug`, opened an aura-perf workspace mid-turn via CDP. 233 tool calls completed with `Done`, **zero new** `Stream closed` errors appeared during a 15s observation window. The one historical `Stream closed` in the transcript is from a session pre-dating the fix.

### Reviewer reproduction

If you want to validate the failure path on `main`:

1. `git switch main && pnpm install && pnpm --filter @stratosapp/desktop dev`
2. In a workspace with several MCP servers configured, start a thread in `bypassPermissions`.
3. Run a multi-step Bash/Read/Grep task — within a turn or two you should see a tool fail with `Tool permission request failed: Error: Stream closed`, and every subsequent tool in that thread fails identically.
4. Switch to this branch, repeat — the same task should run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)