### PR TITLE
fix(whatsapp): auto-clear stale auth and re-pair on loggedOut

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch --preserveWatchOutput",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@types/node": "^25.2.3",
     "@types/node-telegram-bot-api": "^0.64.7",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/gateway/src/client.test.ts
+++ b/packages/gateway/src/client.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  mkdirSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { clearAuthDir } from "./client";
+
+describe("clearAuthDir", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "stratos-gateway-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("wipes every file in the directory", () => {
+    writeFileSync(join(dir, "creds.json"), "{}");
+    writeFileSync(join(dir, "lid-mapping-15551234567.json"), "{}");
+    writeFileSync(join(dir, "session-1.json"), "{}");
+    expect(readdirSync(dir)).toHaveLength(3);
+
+    clearAuthDir(dir);
+
+    expect(readdirSync(dir)).toHaveLength(0);
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it("is a no-op when the directory does not exist", () => {
+    const missing = join(dir, "does-not-exist");
+    expect(() => clearAuthDir(missing)).not.toThrow();
+  });
+
+  it("handles an empty directory", () => {
+    clearAuthDir(dir);
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it("only touches the given directory, not subdirectories", () => {
+    const sub = join(dir, "nested");
+    mkdirSync(sub);
+    writeFileSync(join(sub, "keep.json"), "{}");
+    writeFileSync(join(dir, "wipe.json"), "{}");
+
+    clearAuthDir(dir);
+
+    expect(readdirSync(dir)).toEqual(["nested"]);
+    expect(readdirSync(sub)).toEqual(["keep.json"]);
+  });
+});

--- a/packages/gateway/src/client.ts
+++ b/packages/gateway/src/client.ts
@@ -7,8 +7,25 @@ import makeWASocket, {
 } from "@whiskeysockets/baileys";
 import { Boom } from "@hapi/boom";
 import pino from "pino";
+import { existsSync, readdirSync, unlinkSync } from "fs";
+import { join } from "path";
 
 const logger = pino({ level: "silent" });
+
+/**
+ * Wipe every file under `authDir`. Exported for unit testing — the gateway
+ * calls this when WhatsApp says our saved session is no longer valid.
+ */
+export function clearAuthDir(authDir: string): void {
+  if (!existsSync(authDir)) return;
+  for (const f of readdirSync(authDir)) {
+    try {
+      unlinkSync(join(authDir, f));
+    } catch {
+      // best-effort: a single file failing must not block re-pairing
+    }
+  }
+}
 
 export type ResolveJid = (jid: string) => Promise<string>;
 export type OnReady = (sock: WASocket, resolveJid: ResolveJid) => void;
@@ -27,8 +44,17 @@ export async function startWhatsApp(
   callbacks: WhatsAppCallbacks,
   stopped: () => boolean,
 ): Promise<void> {
-  const { state, saveCreds } = await useMultiFileAuthState(authDir);
+  let { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
+
+  // Refresh credentials after wiping the auth dir so the next connect()
+  // pairs from scratch and triggers a QR.
+  async function resetAuthState(): Promise<void> {
+    clearAuthDir(authDir);
+    const fresh = await useMultiFileAuthState(authDir);
+    state = fresh.state;
+    saveCreds = fresh.saveCreds;
+  }
 
   // Cache lid → phoneNumber JID from contacts events.
   const lidToPhone = new Map<string, string>();
@@ -86,30 +112,42 @@ export async function startWhatsApp(
       ),
     );
 
-    sock.ev.on("connection.update", ({ connection, lastDisconnect, qr }) => {
-      if (qr) callbacks.onQr(qr);
+    sock.ev.on(
+      "connection.update",
+      async ({ connection, lastDisconnect, qr }) => {
+        if (qr) callbacks.onQr(qr);
 
-      if (connection === "open") {
-        callbacks.onStatus("connected");
-        callbacks.onLog("[whatsapp] connected");
-        onReady(sock, (jid) => resolveJid(sock, jid));
-      }
-
-      if (connection === "close") {
-        callbacks.onStatus("disconnected");
-        const code = (lastDisconnect?.error as Boom)?.output?.statusCode;
-        if (code === DisconnectReason.loggedOut) {
-          callbacks.onLog(
-            "[whatsapp] logged out — delete auth and reconnect to re-pair",
-          );
-        } else if (!stopped()) {
-          callbacks.onLog(
-            `[whatsapp] disconnected (${code}), reconnecting in 5s…`,
-          );
-          setTimeout(connect, 5000);
+        if (connection === "open") {
+          callbacks.onStatus("connected");
+          callbacks.onLog("[whatsapp] connected");
+          onReady(sock, (jid) => resolveJid(sock, jid));
         }
-      }
-    });
+
+        if (connection === "close") {
+          callbacks.onStatus("disconnected");
+          const code = (lastDisconnect?.error as Boom)?.output?.statusCode;
+          if (code === DisconnectReason.loggedOut) {
+            callbacks.onLog(
+              "[whatsapp] logged out — clearing stale auth and re-pairing",
+            );
+            if (stopped()) return;
+            try {
+              await resetAuthState();
+              await connect();
+            } catch (err) {
+              callbacks.onLog(
+                `[whatsapp] auth reset failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          } else if (!stopped()) {
+            callbacks.onLog(
+              `[whatsapp] disconnected (${code}), reconnecting in 5s…`,
+            );
+            setTimeout(connect, 5000);
+          }
+        }
+      },
+    );
   }
 
   await connect();

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.3)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.4)
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
## Summary
- Clicking **Connect** in WhatsApp settings was flickering with no QR shown when the saved Baileys session was invalidated (`DisconnectReason.loggedOut`). The old code logged `"delete auth and reconnect to re-pair"` but never actually did it, so every Connect press repeated the same failure.
- Now wipes `whatsapp-auth/`, refreshes state via `useMultiFileAuthState`, and reconnects — the next cycle produces a fresh QR through the normal flow.
- Adds a `clearAuthDir` unit test (4 cases) and wires `vitest` into `@stratosapp/gateway`.

## Test plan
- [x] Empty auth → click Connect → QR appears (no regression).
- [x] Stale auth copied in (19,553 files) → click Connect → log shows `[whatsapp] logged out — clearing stale auth and re-pairing`, auth dir wiped to 0 files, fresh QR appears in UI.
- [x] `pnpm --filter @stratosapp/gateway test` — 4/4 pass.
- [x] `pnpm --filter @stratosapp/gateway typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)