### PR TITLE
fix(threads): auto-delete claude-code threads whose SDK JSONL was pruned

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export { FileStorageAdapter } from "./storage/file-adapter";
 export {
   parseSessionCompleteNotification,
   parseTaskNotification,
+  isSdkSessionMissing,
 } from "./storage/sdk-transcript";
 export type { TraceEntry } from "./storage/trace.store";
 export {

--- a/packages/core/src/storage/sdk-transcript.ts
+++ b/packages/core/src/storage/sdk-transcript.ts
@@ -1,4 +1,5 @@
 import { readFile } from "fs/promises";
+import { existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import {
@@ -238,6 +239,29 @@ function buildJsonlPath(sessionId: string, cwd: string): string {
     sanitizePath(cwd),
     `${sessionId}.jsonl`,
   );
+}
+
+/**
+ * Returns true when the SDK's JSONL file for a session no longer exists —
+ * i.e. Claude Code has pruned the transcript. The signal is deliberately
+ * conservative: any ambiguity (cwd unknown and SDK scan fails) returns
+ * false so we never accidentally delete a live thread.
+ *
+ * When `cwd` is provided we check the deterministic path directly. Without
+ * it we fall back to the SDK's `getSessionInfo` scan, which returns
+ * `undefined` only when the session file cannot be found in any project.
+ */
+export async function isSdkSessionMissing(
+  sessionId: string,
+  cwd?: string,
+): Promise<boolean> {
+  if (cwd) return !existsSync(buildJsonlPath(sessionId, cwd));
+  try {
+    const info = await getSessionInfo(sessionId);
+    return info === undefined;
+  } catch {
+    return false;
+  }
 }
 
 // The Claude SDK writes a `{"type":"system","subtype":"compact_boundary",...}` entry

--- a/packages/desktop/src/main/__tests__/thread.ipc.test.ts
+++ b/packages/desktop/src/main/__tests__/thread.ipc.test.ts
@@ -19,6 +19,16 @@ const mockStorage = {
   updateFolder: vi.fn(),
 };
 
+const mockBroadcasts: string[] = [];
+const mockWindow = {
+  isDestroyed: () => false,
+  webContents: {
+    send: vi.fn((channel: string) => {
+      mockBroadcasts.push(channel);
+    }),
+  },
+};
+
 vi.mock("electron", () => ({
   app: { isPackaged: false },
   ipcMain: {
@@ -27,14 +37,19 @@ vi.mock("electron", () => ({
     }),
     removeHandler: vi.fn(),
   },
+  BrowserWindow: {
+    getAllWindows: () => [mockWindow],
+  },
 }));
 
+const isSdkSessionMissingMock = vi.fn().mockResolvedValue(false);
 vi.mock("@stratosapp/core", () => ({
   FileStorageAdapter: vi.fn(function MockFileStorageAdapter() {
     return mockStorage;
   }),
   readTraceEntries: vi.fn(),
   clearTraceFile: vi.fn(),
+  isSdkSessionMissing: isSdkSessionMissingMock,
 }));
 
 describe("thread IPC session reset behavior", () => {
@@ -99,6 +114,86 @@ describe("thread IPC session reset behavior", () => {
     );
     expect(mockStorage.updateThread).toHaveBeenCalledWith("thread-1", {
       cwd: "/tmp/other",
+    });
+  });
+
+  describe("THREADS_LOAD_MESSAGES auto-cleanup", () => {
+    beforeEach(() => {
+      isSdkSessionMissingMock.mockReset().mockResolvedValue(false);
+      mockBroadcasts.length = 0;
+    });
+
+    it("deletes a claude-code thread when the SDK JSONL is missing", async () => {
+      mockStorage.getThread.mockReturnValue({
+        id: "thread-1",
+        provider: "claude-code",
+        sessionId: "sess-abc",
+        cwd: "/tmp/proj",
+      });
+      isSdkSessionMissingMock.mockResolvedValueOnce(true);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LOAD_MESSAGES);
+      const result = await handler?.({}, "thread-1");
+
+      expect(isSdkSessionMissingMock).toHaveBeenCalledWith(
+        "sess-abc",
+        "/tmp/proj",
+      );
+      expect(clearSession).toHaveBeenCalledWith("thread-1");
+      expect(mockStorage.deleteThread).toHaveBeenCalledWith("thread-1");
+      expect(mockBroadcasts).toContain(IPC_CHANNELS.THREADS_CHANGED);
+      expect(mockStorage.loadMessages).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("loads normally when the SDK JSONL exists", async () => {
+      mockStorage.getThread.mockReturnValue({
+        id: "thread-1",
+        provider: "claude-code",
+        sessionId: "sess-abc",
+        cwd: "/tmp/proj",
+      });
+      mockStorage.loadMessages.mockResolvedValueOnce([
+        { id: "m1", role: "user", content: "hi", timestamp: 1 },
+      ]);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LOAD_MESSAGES);
+      const result = await handler?.({}, "thread-1");
+
+      expect(mockStorage.deleteThread).not.toHaveBeenCalled();
+      expect(mockStorage.loadMessages).toHaveBeenCalledWith("thread-1");
+      expect(result).toHaveLength(1);
+    });
+
+    it("skips the check for non-claude-code threads", async () => {
+      mockStorage.getThread.mockReturnValue({
+        id: "thread-1",
+        provider: "codex",
+        sessionId: "sess-abc",
+        cwd: "/tmp/proj",
+      });
+      mockStorage.loadMessages.mockResolvedValueOnce([]);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LOAD_MESSAGES);
+      await handler?.({}, "thread-1");
+
+      expect(isSdkSessionMissingMock).not.toHaveBeenCalled();
+      expect(mockStorage.loadMessages).toHaveBeenCalledWith("thread-1");
+    });
+
+    it("skips the check for threads with no sessionId", async () => {
+      mockStorage.getThread.mockReturnValue({
+        id: "thread-1",
+        provider: "claude-code",
+        sessionId: undefined,
+        cwd: "/tmp/proj",
+      });
+      mockStorage.loadMessages.mockResolvedValueOnce([]);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LOAD_MESSAGES);
+      await handler?.({}, "thread-1");
+
+      expect(isSdkSessionMissingMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/desktop/src/main/threads/thread.ipc.ts
+++ b/packages/desktop/src/main/threads/thread.ipc.ts
@@ -10,6 +10,7 @@ import {
   FileStorageAdapter,
   readTraceEntries,
   clearTraceFile,
+  isSdkSessionMissing,
 } from "@stratosapp/core";
 import type {
   StoredMessage,
@@ -291,40 +292,71 @@ export function registerThreadIpc(storage = new FileStorageAdapter()): void {
     },
   );
 
+  async function performThreadDelete(threadId: string): Promise<boolean> {
+    const thread = await storage.getThread(threadId);
+    if (thread?.worktree) {
+      try {
+        await execFileAsync(
+          "git",
+          ["worktree", "remove", thread.worktree.path, "--force"],
+          {
+            cwd: thread.worktree.sourceRepoPath,
+            encoding: "utf-8",
+            timeout: 10000,
+          },
+        );
+      } catch {
+        // Worktree may already be removed
+      }
+    }
+
+    clearSessionFn?.(threadId);
+    onThreadDeletedFn?.(threadId);
+    return storage.deleteThread(threadId);
+  }
+
+  function broadcastThreadsChanged(): void {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send(IPC_CHANNELS.THREADS_CHANGED);
+      }
+    }
+  }
+
   ipcMain.handle(
     IPC_CHANNELS.THREADS_DELETE,
     async (_event, threadId: string) => {
-      // Clean up worktree if one exists
-      const thread = await storage.getThread(threadId);
-      if (thread?.worktree) {
-        try {
-          await execFileAsync(
-            "git",
-            ["worktree", "remove", thread.worktree.path, "--force"],
-            {
-              cwd: thread.worktree.sourceRepoPath,
-              encoding: "utf-8",
-              timeout: 10000,
-            },
-          );
-        } catch {
-          // Worktree may already be removed
-        }
-      }
-
-      clearSessionFn?.(threadId);
-      onThreadDeletedFn?.(threadId);
-      return storage.deleteThread(threadId);
+      return performThreadDelete(threadId);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.THREADS_LOAD_MESSAGES,
     async (_event, threadId: string) => {
+      // Auto-cleanup: if this is a claude-code thread whose SDK JSONL has
+      // been pruned by Claude Code, delete the thread. Skip the check for
+      // running threads to avoid a race with in-flight SDK writes.
+      const thread = storage.getThread(threadId);
+      const runningIds = getRunningIdsFn?.() ?? [];
+      if (
+        thread?.provider === "claude-code" &&
+        thread.sessionId &&
+        !runningIds.includes(threadId)
+      ) {
+        const missing = await isSdkSessionMissing(
+          thread.sessionId,
+          thread.cwd,
+        );
+        if (missing) {
+          await performThreadDelete(threadId);
+          broadcastThreadsChanged();
+          return [];
+        }
+      }
+
       try {
         return await storage.loadMessages(threadId);
       } catch (err) {
-        const thread = storage.getThread(threadId);
         emitDiagnostic(
           "Failed to load thread messages",
           err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary

- Claude Code prunes old JSONL transcripts at `~/.claude/projects/<sanitized-cwd>/<sessionId>.jsonl`. Since commit cc00c78 made the SDK the sole source of truth, any thread whose JSONL is gone silently renders empty — the sidebar keeps a graveyard of dead threads with no history.
- Add `isSdkSessionMissing()` in `sdk-transcript.ts` — uses `existsSync()` on the deterministic path when cwd is known, falls back to `getSessionInfo() === undefined` otherwise. Any ambiguity returns false, so live threads are never wrongly deleted.
- On `THREADS_LOAD_MESSAGES`, if the thread is claude-code with a sessionId and not currently running, and the JSONL is missing, run the full delete cleanup (worktree removal, session clearer, deletion hook, storage delete) and broadcast `THREADS_CHANGED`. The running-thread guard prevents racing an in-flight SDK write.

## Test plan

- [x] `pnpm --filter @stratosapp/core typecheck` — clean
- [x] `pnpm --filter @stratosapp/desktop typecheck` — clean
- [x] `pnpm --filter @stratosapp/core test` — 221 passed
- [x] `pnpm --filter @stratosapp/desktop test` — 229 passed (10 in `thread.ipc.test.ts`, including 4 new cases: delete-on-missing, normal-load-when-present, skip-for-non-claude-code, skip-when-no-sessionId)
- [ ] Manual: click a thread whose Claude Code JSONL has been pruned → thread disappears from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)