### PR TITLE
feat(threads): sweep stale claude-code threads on THREADS_LIST

### DIFF
--- a/packages/desktop/src/main/__tests__/thread.ipc.test.ts
+++ b/packages/desktop/src/main/__tests__/thread.ipc.test.ts
@@ -197,6 +197,90 @@ describe("thread IPC session reset behavior", () => {
     });
   });
 
+  describe("THREADS_LIST reaping", () => {
+    beforeEach(() => {
+      isSdkSessionMissingMock.mockReset().mockResolvedValue(false);
+      mockBroadcasts.length = 0;
+    });
+
+    it("filters out and deletes stale claude-code threads", async () => {
+      const alive = {
+        id: "alive",
+        provider: "claude-code" as const,
+        sessionId: "s-alive",
+        cwd: "/tmp/alive",
+      };
+      const stale = {
+        id: "stale",
+        provider: "claude-code" as const,
+        sessionId: "s-stale",
+        cwd: "/tmp/stale",
+      };
+      mockStorage.listThreads.mockReturnValue([alive, stale]);
+      // Second call returns "stale" as missing
+      isSdkSessionMissingMock.mockImplementation(async (sid: string) =>
+        sid === "s-stale",
+      );
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LIST);
+      const result = (await handler?.({})) as typeof alive[];
+
+      expect(result.map((t) => t.id)).toEqual(["alive"]);
+      expect(clearSession).toHaveBeenCalledWith("stale");
+      expect(clearSession).not.toHaveBeenCalledWith("alive");
+      expect(mockStorage.deleteThread).toHaveBeenCalledWith("stale");
+      expect(mockStorage.deleteThread).not.toHaveBeenCalledWith("alive");
+    });
+
+    it("returns the full list untouched when no thread is stale", async () => {
+      mockStorage.listThreads.mockReturnValue([
+        {
+          id: "t1",
+          provider: "claude-code",
+          sessionId: "s1",
+          cwd: "/tmp/1",
+        },
+        {
+          id: "t2",
+          provider: "codex",
+          sessionId: "s2",
+          cwd: "/tmp/2",
+        },
+      ]);
+      isSdkSessionMissingMock.mockResolvedValue(false);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LIST);
+      const result = (await handler?.({})) as { id: string }[];
+
+      expect(result.map((t) => t.id)).toEqual(["t1", "t2"]);
+      expect(mockStorage.deleteThread).not.toHaveBeenCalled();
+    });
+
+    it("does not touch non-claude-code threads or threads without sessionId", async () => {
+      mockStorage.listThreads.mockReturnValue([
+        {
+          id: "codex-thread",
+          provider: "codex",
+          sessionId: "s-codex",
+          cwd: "/tmp/codex",
+        },
+        {
+          id: "no-session",
+          provider: "claude-code",
+          sessionId: undefined,
+          cwd: "/tmp/nosess",
+        },
+      ]);
+
+      const handler = handleMocks.get(IPC_CHANNELS.THREADS_LIST);
+      const result = (await handler?.({})) as { id: string }[];
+
+      expect(result.map((t) => t.id)).toEqual(["codex-thread", "no-session"]);
+      expect(isSdkSessionMissingMock).not.toHaveBeenCalled();
+      expect(mockStorage.deleteThread).not.toHaveBeenCalled();
+    });
+  });
+
   describe("THREADS_CREATE provider settings pre-population", () => {
     // Each test resets modules so the vi.doMock for settings.store takes effect
     // on the fresh thread.ipc import. The outer beforeEach only does clearAllMocks,

--- a/packages/desktop/src/main/threads/thread.ipc.ts
+++ b/packages/desktop/src/main/threads/thread.ipc.ts
@@ -67,8 +67,89 @@ function emitDiagnostic(
 }
 
 export function registerThreadIpc(storage = new FileStorageAdapter()): void {
+  // Track threads whose slow worktree cleanup is already queued so we don't
+  // pile up duplicate `git worktree remove` calls when THREADS_LIST is
+  // called repeatedly before the deferred cleanup lands.
+  const worktreeCleanupPending = new Set<string>();
+
+  async function reapStaleClaudeCodeThreads(
+    threads: Array<ReturnType<typeof storage.listThreads>[number]>,
+  ): Promise<{
+    kept: typeof threads;
+    stale: typeof threads;
+  }> {
+    const runningIds = new Set(getRunningIdsFn?.() ?? []);
+    // Parallel existsSync-backed check. `isSdkSessionMissing` is synchronous
+    // when cwd is provided (the common case), so this fans out cheaply.
+    const staleFlags = await Promise.all(
+      threads.map((t) => {
+        if (
+          t.provider !== "claude-code" ||
+          !t.sessionId ||
+          runningIds.has(t.id)
+        ) {
+          return Promise.resolve(false);
+        }
+        return isSdkSessionMissing(t.sessionId, t.cwd);
+      }),
+    );
+    const kept: typeof threads = [];
+    const stale: typeof threads = [];
+    for (let i = 0; i < threads.length; i++) {
+      if (staleFlags[i]) stale.push(threads[i]);
+      else kept.push(threads[i]);
+    }
+    return { kept, stale };
+  }
+
   ipcMain.handle(IPC_CHANNELS.THREADS_LIST, async () => {
-    return storage.listThreads();
+    const all = storage.listThreads();
+    const { kept, stale } = await reapStaleClaudeCodeThreads(all);
+    if (stale.length === 0) return kept;
+
+    // Fast synchronous cleanup so subsequent LIST calls see the reaped
+    // threads gone from storage. This also drops any active session and
+    // fires the delete hook (loop-wakeup timers etc.) immediately.
+    for (const t of stale) {
+      clearSessionFn?.(t.id);
+      onThreadDeletedFn?.(t.id);
+      storage.deleteThread(t.id);
+    }
+    console.log(
+      `[thread-reaper] deleted ${stale.length} stale claude-code thread(s): ${stale
+        .map((t) => t.id)
+        .join(", ")}`,
+    );
+
+    // Defer git worktree removal — it can take multiple seconds per worktree
+    // and shouldn't block the sidebar render.
+    const worktreesToClean = stale.filter(
+      (t) => t.worktree && !worktreeCleanupPending.has(t.id),
+    );
+    if (worktreesToClean.length > 0) {
+      for (const t of worktreesToClean) worktreeCleanupPending.add(t.id);
+      setImmediate(async () => {
+        for (const t of worktreesToClean) {
+          try {
+            await execFileAsync(
+              "git",
+              ["worktree", "remove", t.worktree!.path, "--force"],
+              {
+                cwd: t.worktree!.sourceRepoPath,
+                encoding: "utf-8",
+                timeout: 10000,
+              },
+            );
+          } catch {
+            // Worktree may already be removed
+          } finally {
+            worktreeCleanupPending.delete(t.id);
+          }
+        }
+      });
+    }
+
+    return kept;
   });
 
   ipcMain.handle(IPC_CHANNELS.THREADS_GET_ACTIVE, async () => {


### PR DESCRIPTION
## Summary

- Follow-up to #86. That fix only reaped a stale claude-code thread when the user clicked it — anyone with a graveyard of dead threads had to open each one before it disappeared from the sidebar.
- Add a reap pass to `THREADS_LIST`. Every claude-code thread with a `sessionId` (and not currently running) is checked in parallel via `isSdkSessionMissing`. Stale ones are filtered out of the response so the UI never renders them.
- Synchronously drop session + fire delete hook + delete from storage so subsequent LIST calls stay consistent. Defer the slow `git worktree remove` to `setImmediate`, guarded by a Set so repeated LIST calls don't queue duplicate git commands.
- `isSdkSessionMissing` is a single `fs.existsSync` when `cwd` is known (common case), so parallel fan-out over ~100 threads is milliseconds.

## Test plan

- [x] `pnpm --filter @stratosapp/desktop typecheck` — clean
- [x] `pnpm --filter @stratosapp/desktop test` — 232 pass (13 in `thread.ipc.test.ts`, including 3 new: filters+deletes stale, returns full list when none stale, ignores non-claude-code / no-sessionId)
- [x] `pnpm --filter @stratosapp/core test` — 221 pass
- [ ] Manual: reopen Stratos with a mix of live + JSONL-pruned threads → dead ones never render in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)