### PR TITLE
fix(copilot): stop silently dropping images larger than ~1 MB

### DIFF
--- a/packages/core/src/__tests__/copilot.provider.test.ts
+++ b/packages/core/src/__tests__/copilot.provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   CopilotProvider,
+  imagesToAttachments,
   normalizeCopilotToolName,
 } from "../providers/copilot.provider";
 
@@ -84,5 +85,49 @@ describe("normalizeCopilotToolName", () => {
     expect(normalizeCopilotToolName("READ")).toBe("Read");
     expect(normalizeCopilotToolName("Web-Fetch")).toBe("WebFetch");
     expect(normalizeCopilotToolName("str-replace")).toBe("Edit");
+  });
+});
+
+describe("imagesToAttachments", () => {
+  it("returns undefined for empty or missing inputs", () => {
+    expect(imagesToAttachments(undefined)).toBeUndefined();
+    expect(imagesToAttachments([])).toBeUndefined();
+  });
+
+  it("strips the data-url prefix and preserves the base64 payload", () => {
+    const data = "iVBORw0KGgo=";
+    const out = imagesToAttachments([
+      { dataUrl: `data:image/png;base64,${data}`, mimeType: "image/png" },
+    ]);
+    expect(out).toEqual([{ type: "blob", mimeType: "image/png", data }]);
+  });
+
+  it("passes large images through without dropping them", () => {
+    // Simulate a JPEG larger than the old 1 MB cap that used to silently drop
+    // attachments. Users regularly attach phone photos in that size range.
+    const bigData = "A".repeat(3_000_000);
+    const out = imagesToAttachments([
+      {
+        dataUrl: `data:image/jpeg;base64,${bigData}`,
+        mimeType: "image/jpeg",
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out?.[0]).toMatchObject({
+      type: "blob",
+      mimeType: "image/jpeg",
+      data: bigData,
+    });
+  });
+
+  it("preserves the order of multiple attachments", () => {
+    const out = imagesToAttachments([
+      { dataUrl: "data:image/png;base64,AAA", mimeType: "image/png" },
+      { dataUrl: "data:image/jpeg;base64,BBB", mimeType: "image/jpeg" },
+    ]);
+    expect(out).toEqual([
+      { type: "blob", mimeType: "image/png", data: "AAA" },
+      { type: "blob", mimeType: "image/jpeg", data: "BBB" },
+    ]);
   });
 });

--- a/packages/core/src/providers/copilot.provider.ts
+++ b/packages/core/src/providers/copilot.provider.ts
@@ -150,7 +150,6 @@ function getSdk(): typeof import("@github/copilot-sdk") {
 
 // ─── Streaming caps (mirror the Claude provider's main-process safety nets) ──
 
-const STREAM_IMAGE_DATA_CAP = 512_000;
 const STREAM_TOOL_OUTPUT_CAP = 256_000;
 
 function capStreamingToolOutput(output: string): string {
@@ -297,14 +296,13 @@ function translateCustomAgents(
 
 // ─── Image attachment translation ────────────────────────────────────────────
 
-function imagesToAttachments(
+export function imagesToAttachments(
   images: SendMessageParams["images"] | undefined,
 ): MessageOptions["attachments"] | undefined {
   if (!images || images.length === 0) return undefined;
   const out: NonNullable<MessageOptions["attachments"]> = [];
   for (const img of images) {
     const data = img.dataUrl.replace(/^data:[^;]+;base64,/, "");
-    if (data.length > STREAM_IMAGE_DATA_CAP * 2) continue; // skip outliers
     out.push({ type: "blob", mimeType: img.mimeType, data });
   }
   return out.length > 0 ? out : undefined;
@@ -1308,13 +1306,12 @@ export class CopilotProvider implements AgentProvider {
     const unsubscribe = () => {};
 
     // Drive the send (don't await; events flow asynchronously into the queue).
+    const attachments = imagesToAttachments(params.images);
     const messageOptions: MessageOptions = {
       prompt: params.prompt,
       mode: "immediate",
       agentMode: stratosModeToCopilotAgentMode(mode),
-      ...(imagesToAttachments(params.images)
-        ? { attachments: imagesToAttachments(params.images) }
-        : {}),
+      ...(attachments ? { attachments } : {}),
     };
 
     const sendPromise = session.send(messageOptions).catch((err) => {


### PR DESCRIPTION
## Summary

The Copilot provider's `imagesToAttachments` silently rejected any base64 payload exceeding `STREAM_IMAGE_DATA_CAP * 2` (~1 MB), so typical phone JPEGs never reached the SDK. The Copilot model would then respond with "no image was actually attached" even though the user could see the image in their chat bubble.

The cap was misapplied — `STREAM_IMAGE_DATA_CAP` exists to strip oversized images from *incoming* `tool_result` payloads to prevent main-process OOM (see `stripOversizedImageData` in the Claude provider). It has no reason to gate *outgoing* user attachments, which the SDK forwards over the wire without holding in main-process memory. The Claude provider does not cap outgoing user images.

## Changes

- `packages/core/src/providers/copilot.provider.ts`
  - Remove the `data.length > STREAM_IMAGE_DATA_CAP * 2` check in `imagesToAttachments`.
  - Drop the now-unused `STREAM_IMAGE_DATA_CAP` constant.
  - Export `imagesToAttachments` and cache the return value so it's computed once, not twice.
- `packages/core/src/__tests__/copilot.provider.test.ts`
  - Four new unit tests, including a 3M-char base64 regression case that would have been dropped by the old cap.

## How the bug was found

Traced `~/.stratos/threads/traces/hollow-pearl.jsonl`: the SDK's `user.message` event showed `attachments_count=1` for a small PNG (Slack screenshot) but `attachments_count=0` for JPEGs the user attached to subsequent messages — pinpointing the silent drop in the provider.

## Test plan

- [x] `pnpm --filter @stratosapp/core test` — all 225 tests pass (38 in copilot.provider.test.ts, including 4 new)
- [x] `tsc --noEmit` clean
- [x] End-to-end via CDP: sent a 2M-char base64 image to the copilot thread; SDK trace confirmed the attachment was received (was previously dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)