### PR TITLE
fix(copilot): stop doubling replies when streaming

### DIFF
--- a/packages/core/src/__tests__/copilot.provider.test.ts
+++ b/packages/core/src/__tests__/copilot.provider.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   CopilotProvider,
   imagesToAttachments,
+  makeBridgeContext,
+  mapEvent,
   normalizeCopilotToolName,
 } from "../providers/copilot.provider";
+import type { AgentMessage } from "../providers/types";
 
 describe("CopilotProvider", () => {
   it("instantiates with correct name", () => {
@@ -129,5 +132,84 @@ describe("imagesToAttachments", () => {
       { type: "blob", mimeType: "image/png", data: "AAA" },
       { type: "blob", mimeType: "image/jpeg", data: "BBB" },
     ]);
+  });
+});
+
+// Helper: turn a sequence of Copilot SessionEvents into the AgentMessage
+// stream that the renderer would consume, and pull out just the `text` /
+// `thinking` entries — the ones the concatenating renderer would splice
+// together into the visible assistant bubble.
+function runBridge(
+  events: Array<{ type: string; data?: Record<string, unknown> }>,
+): AgentMessage[] {
+  const ctx = makeBridgeContext();
+  const out: AgentMessage[] = [];
+  for (const ev of events) {
+    for (const m of mapEvent(ev as never, ctx)) out.push(m);
+  }
+  return out;
+}
+
+describe("copilot mapEvent — streaming vs terminal message", () => {
+  it("does not re-emit text from assistant.message when deltas already streamed it (regression: duplicated responses)", () => {
+    const messages = runBridge([
+      { type: "assistant.message_start" },
+      { type: "assistant.message_delta", data: { deltaContent: "Hello" } },
+      { type: "assistant.message_delta", data: { deltaContent: "! 👋" } },
+      { type: "assistant.message", data: { content: "Hello! 👋" } },
+      { type: "session.idle" },
+    ]);
+    const textPieces = messages
+      .filter((m) => m.type === "text")
+      .map((m) => (m as { content: string }).content);
+    // Streaming delivered "Hello" + "! 👋"; the terminal event must NOT
+    // re-yield "Hello! 👋" or the renderer would concatenate a second copy.
+    expect(textPieces).toEqual(["Hello", "! 👋"]);
+    // The `result` synthesis on session.idle should still carry the full text.
+    const result = messages.find((m) => m.type === "result") as
+      | { content: string }
+      | undefined;
+    expect(result?.content).toBe("Hello! 👋");
+  });
+
+  it("does emit text from assistant.message when no deltas streamed (non-streaming providers)", () => {
+    const messages = runBridge([
+      { type: "assistant.message_start" },
+      { type: "assistant.message", data: { content: "Just say hello" } },
+      { type: "session.idle" },
+    ]);
+    const textPieces = messages
+      .filter((m) => m.type === "text")
+      .map((m) => (m as { content: string }).content);
+    expect(textPieces).toEqual(["Just say hello"]);
+  });
+
+  it("does not re-emit reasoning from assistant.reasoning when deltas already streamed it", () => {
+    const messages = runBridge([
+      { type: "assistant.message_start" },
+      { type: "assistant.reasoning_delta", data: { deltaContent: "Think" } },
+      { type: "assistant.reasoning_delta", data: { deltaContent: "ing…" } },
+      { type: "assistant.reasoning", data: { content: "Thinking…" } },
+    ]);
+    const thinkingPieces = messages
+      .filter((m) => m.type === "thinking")
+      .map((m) => (m as { content: string }).content);
+    expect(thinkingPieces).toEqual(["Think", "ing…"]);
+  });
+
+  it("resets streaming guards between messages so a fresh non-streamed reply is emitted", () => {
+    const messages = runBridge([
+      { type: "assistant.message_start" },
+      { type: "assistant.message_delta", data: { deltaContent: "First" } },
+      { type: "assistant.message", data: { content: "First" } },
+      { type: "assistant.message_start" },
+      { type: "assistant.message", data: { content: "Second" } },
+    ]);
+    const textPieces = messages
+      .filter((m) => m.type === "text")
+      .map((m) => (m as { content: string }).content);
+    // First message streamed → terminal suppressed. Second message did not
+    // stream → terminal must be emitted.
+    expect(textPieces).toEqual(["First", "Second"]);
   });
 });

--- a/packages/core/src/providers/copilot.provider.ts
+++ b/packages/core/src/providers/copilot.provider.ts
@@ -399,6 +399,11 @@ interface BridgeContext {
   finalModel: string | undefined;
   finalCost: number | undefined;
   contextWindow: number | null;
+  // Streaming guards — when a delta stream has already delivered text/reasoning
+  // for the current message, the terminal assistant.message / assistant.reasoning
+  // event must NOT re-yield the same content or the renderer will concatenate it.
+  textWasStreamed: boolean;
+  thinkingWasStreamed: boolean;
   // Per-tool-call accounting
   pendingToolNames: Map<string, string>; // toolCallId → toolName (after normalize)
   // Sub-agent task tracking — surface via task_notification + nested tool_use parentToolUseId
@@ -411,7 +416,7 @@ interface BridgeContext {
   resultEmitted: boolean;
 }
 
-function makeBridgeContext(): BridgeContext {
+export function makeBridgeContext(): BridgeContext {
   return {
     sessionId: undefined,
     cachedTools: [],
@@ -423,6 +428,8 @@ function makeBridgeContext(): BridgeContext {
     finalModel: undefined,
     finalCost: undefined,
     contextWindow: null,
+    textWasStreamed: false,
+    thinkingWasStreamed: false,
     pendingToolNames: new Map(),
     subagentTaskByCallId: new Map(),
     agentIdToParentToolCallId: new Map(),
@@ -476,7 +483,7 @@ function emitInitIfReady(ctx: BridgeContext): AgentMessage | null {
   };
 }
 
-function* mapEvent(
+export function* mapEvent(
   ev: SessionEvent,
   ctx: BridgeContext,
 ): Generator<AgentMessage> {
@@ -543,13 +550,17 @@ function* mapEvent(
     }
 
     case "assistant.message_start":
-      // Marks streaming start — no AgentMessage; deltas will arrive next.
+      // Reset per-message streaming guards so the next message_delta stream is
+      // tracked independently from any previous one on the same session.
+      ctx.textWasStreamed = false;
+      ctx.thinkingWasStreamed = false;
       return;
 
     case "assistant.message_delta": {
       const d: any = ev.data ?? {};
       const content = typeof d.deltaContent === "string" ? d.deltaContent : "";
       if (!content) return;
+      ctx.textWasStreamed = true;
       yield { type: "text", content, isStreaming: true };
       return;
     }
@@ -566,7 +577,10 @@ function* mapEvent(
         };
       }
       if (d.model && !ctx.finalModel) ctx.finalModel = d.model;
-      if (content) {
+      // Only surface the terminal message as `text` when streaming deltas did
+      // not already deliver it — otherwise the renderer concatenates the full
+      // message onto the streamed content, doubling the reply.
+      if (content && !ctx.textWasStreamed) {
         yield { type: "text", content, isStreaming: false };
       }
       // Inline tool_requests are also surfaced via `tool.execution_start`
@@ -578,6 +592,7 @@ function* mapEvent(
       const d: any = ev.data ?? {};
       const content = typeof d.deltaContent === "string" ? d.deltaContent : "";
       if (!content) return;
+      ctx.thinkingWasStreamed = true;
       yield { type: "thinking", content, isStreaming: true };
       return;
     }
@@ -586,6 +601,7 @@ function* mapEvent(
       const d: any = ev.data ?? {};
       const content = typeof d.content === "string" ? d.content : "";
       if (!content) return;
+      if (ctx.thinkingWasStreamed) return;
       yield { type: "thinking", content, isStreaming: false };
       return;
     }


### PR DESCRIPTION
## Summary
- Copilot provider was yielding `text` for both `assistant.message_delta` (streaming chunks) and the terminal `assistant.message` (full content) for the same messageId. The renderer concatenates every text payload, so replies rendered doubled (e.g. `"Hello! 👋Hello! 👋"`).
- Added `textWasStreamed` / `thinkingWasStreamed` flags to the bridge context, reset on `assistant.message_start`, set when a delta is emitted, and checked before emitting the terminal message — mirrors the guard the Claude provider already had (`claude-code.provider.ts:809-864`).
- 4 new unit tests in `copilot.provider.test.ts` cover: delta+terminal suppression, terminal-only (non-streaming) still emits, reasoning-delta suppression, and flag reset between messages. Core suite: 214 → 218 passing.

## Root-cause evidence
The `@github/copilot-sdk` types explicitly document that `assistant.message_start`'s messageId matches **both subsequent deltas AND `assistant.message`** (`session-events.d.ts:2552`). Verified empirically against a real Copilot session with `Just say hello`:

| | Before | After |
|---|---|---|
| Raw SDK events | `message_delta: 2`, `message_full: 1` | `message_delta: 2`, `message_full: 1` |
| Provider `text` yields | 3 | 2 |
| UI-visible text | `"Hello! 👋Hello! 👋"` | `"Hello! 👋"` |

## Test plan
- [x] `pnpm --filter @stratosapp/core test` — 218/218 pass (adds 4 new)
- [x] Manual empirical replay against a live Copilot session (script removed before commit; results above)
- [ ] Reviewer: send any message in the app with the copilot provider — the reply should appear exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)